### PR TITLE
Add chart view to observation detail modal

### DIFF
--- a/src/components/weather/HourlyForecast.jsx
+++ b/src/components/weather/HourlyForecast.jsx
@@ -103,22 +103,29 @@ export default function HourlyForecast({
     }));
   }, [observations]);
 
-  // Get last 24 hours of observations for display (most recent first for the scroll)
-  // Show ALL observations with true 5-minute timestamps - no sampling
-  const displayData = useMemo(() => {
+  // Get last 24 hours of observations for chart (oldest first for proper chart display)
+  const allObservations24h = useMemo(() => {
     if (normalizedObservations.length === 0) return [];
 
-    // Take observations from the last 24 hours
     const now = new Date();
     const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
-    const filtered = normalizedObservations
-      .filter(obs => obs.timestamp >= twentyFourHoursAgo)
-      .reverse(); // Most recent first
+    return normalizedObservations
+      .filter(obs => obs.timestamp >= twentyFourHoursAgo);
+    // Keep oldest first for chart X-axis
+  }, [normalizedObservations]);
+
+  // Get last 24 hours of observations for display (most recent first for the scroll)
+  // Show ALL observations with true 5-minute timestamps - no sampling
+  const displayData = useMemo(() => {
+    if (allObservations24h.length === 0) return [];
+
+    // Reverse for display (most recent first)
+    const reversed = [...allObservations24h].reverse();
 
     // Return all observations (limit to 72 for performance - 6 hours of 5-min data)
-    return filtered.slice(0, 72);
-  }, [normalizedObservations]);
+    return reversed.slice(0, 72);
+  }, [allObservations24h]);
 
   // Format last updated time
   const lastUpdatedText = useMemo(() => {
@@ -240,6 +247,7 @@ export default function HourlyForecast({
         onClose={() => setSelectedIndex(null)}
         observation={selectedObservation}
         surroundingObservations={getSurroundingObservations}
+        allObservations={allObservations24h}
         timezone={timezone}
         useMetric={useMetric}
         onToggleUnits={toggleUnits}


### PR DESCRIPTION
## Summary
- Add Table/Chart tab toggle to observation detail modal
- Implement 24-hour observation history chart using Recharts
- Display temperature, dew point, and humidity on the chart
- Highlight the clicked observation point on the chart

## Features
- **Temperature line** (orange) with gradient area fill
- **Dew point line** (blue) on same Y-axis as temperature
- **Humidity line** (gray) on right Y-axis (0-100%)
- **Custom tooltip** showing all values with unit conversion support
- **Chart legend** for easy reference
- **Selected observation marker** (orange dot with white stroke)

## Test plan
- [ ] Click on any observation in the widget
- [ ] Verify Table view shows surrounding observations (default)
- [ ] Click Chart tab to switch to chart view
- [ ] Verify chart displays 24h of observation data
- [ ] Hover over chart to see tooltip with values
- [ ] Verify selected observation is highlighted on the chart
- [ ] Test unit toggle (°F/°C) updates chart Y-axis labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)