### PR TITLE
Add Kalshi market brackets detail modal with price charts

### DIFF
--- a/src/components/weather/MarketBracketsModal.jsx
+++ b/src/components/weather/MarketBracketsModal.jsx
@@ -1,0 +1,464 @@
+import { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { X, ChevronDown, ExternalLink, TrendingUp, TrendingDown } from 'lucide-react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts';
+import { useKalshiCandlesticks, PERIODS } from '../../hooks/useKalshiCandlesticks';
+import { useKalshiOrderbook } from '../../hooks/useKalshiOrderbook';
+
+/**
+ * MarketBracketsModal - Detailed view of Kalshi market brackets
+ */
+export default function MarketBracketsModal({
+  brackets,
+  cityName,
+  seriesTicker,
+  closeTime,
+  dayOffset,
+  onDayChange,
+  onClose,
+}) {
+  const [expandedBracket, setExpandedBracket] = useState(null);
+
+  // Format time remaining
+  const formatTimeRemaining = () => {
+    if (!closeTime) return 'Unknown';
+    const now = new Date();
+    const diff = closeTime - now;
+    if (diff <= 0) return 'Closed';
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    return `${hours}h ${minutes}m`;
+  };
+
+  // Get Kalshi URL for trading
+  const getKalshiUrl = () => {
+    const cityMap = {
+      'KXHIGHNY': 'kxhighny/highest-temperature-in-new-york',
+      'KXHIGHCHI': 'kxhighchi/highest-temperature-in-chicago',
+      'KXHIGHLAX': 'kxhighlax/highest-temperature-in-los-angeles',
+      'KXHIGHMIA': 'kxhighmia/highest-temperature-in-miami',
+      'KXHIGHDEN': 'kxhighden/highest-temperature-in-denver',
+      'KXHIGHAUS': 'kxhighaus/highest-temperature-in-austin',
+      'KXHIGHPHIL': 'kxhighphil/highest-temperature-in-philadelphia',
+    };
+    return `https://kalshi.com/markets/${cityMap[seriesTicker] || ''}`;
+  };
+
+  const dayLabel = dayOffset === 0 ? 'Today' : 'Tomorrow';
+
+  // Extract temperature from label for sorting
+  const getTempValue = (label) => {
+    // Handle "X° or above" -> use X
+    // Handle "X° or below" -> use X - 1 (so it sorts before X)
+    // Handle "X° to Y°" -> use X
+    const aboveMatch = label.match(/(\d+)°?\s*(or above|and above|\+)/i);
+    if (aboveMatch) return parseInt(aboveMatch[1], 10);
+
+    const belowMatch = label.match(/(\d+)°?\s*(or below|and below)/i);
+    if (belowMatch) return parseInt(belowMatch[1], 10) - 1;
+
+    const rangeMatch = label.match(/(\d+)/);
+    return rangeMatch ? parseInt(rangeMatch[1], 10) : 0;
+  };
+
+  // Sort brackets by temperature (lowest to highest)
+  const sortedBrackets = [...brackets].sort((a, b) => getTempValue(a.label) - getTempValue(b.label));
+
+  // Find the leading bracket (highest probability)
+  const leadingBracket = brackets.reduce((max, b) => b.yesPrice > (max?.yesPrice || 0) ? b : max, null);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[25] bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="fixed inset-0 z-[100] flex items-center justify-center p-2 sm:p-4 md:left-[300px] lg:right-[344px] pointer-events-none">
+        <div className="glass-elevated relative w-full max-w-lg max-h-[85vh] rounded-2xl overflow-hidden shadow-2xl animate-scale-in pointer-events-auto">
+          {/* Header */}
+          <div className="px-4 pt-4 pb-3 border-b border-white/10">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-white">
+                  Kalshi Markets
+                </h2>
+                <p className="text-sm text-white/60">
+                  Highest temp in {cityName} {dayLabel.toLowerCase()}
+                </p>
+              </div>
+              <button
+                onClick={onClose}
+                className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+              >
+                <X className="w-4 h-4 text-white/70" />
+              </button>
+            </div>
+
+            {/* Day Toggle & Timer */}
+            <div className="flex items-center justify-between mt-3">
+              <div className="flex bg-white/10 rounded-lg p-0.5">
+                <button
+                  onClick={() => onDayChange(0)}
+                  className={`px-3 py-1.5 text-xs font-medium rounded-md transition-all ${
+                    dayOffset === 0
+                      ? 'bg-white/20 text-white'
+                      : 'text-white/50 hover:text-white/70'
+                  }`}
+                >
+                  Today
+                </button>
+                <button
+                  onClick={() => onDayChange(1)}
+                  className={`px-3 py-1.5 text-xs font-medium rounded-md transition-all ${
+                    dayOffset === 1
+                      ? 'bg-white/20 text-white'
+                      : 'text-white/50 hover:text-white/70'
+                  }`}
+                >
+                  Tomorrow
+                </button>
+              </div>
+              <span className="text-xs text-white/40">
+                Closes in {formatTimeRemaining()}
+              </span>
+            </div>
+          </div>
+
+          {/* Brackets List */}
+          <div className="overflow-y-auto max-h-[55vh] glass-scroll">
+            {sortedBrackets.length === 0 ? (
+              <div className="px-4 py-8 text-center text-white/40 text-sm">
+                No markets available for {dayLabel.toLowerCase()}
+              </div>
+            ) : (
+              sortedBrackets.map((bracket, idx) => (
+                <BracketRow
+                  key={bracket.ticker}
+                  bracket={bracket}
+                  seriesTicker={seriesTicker}
+                  isExpanded={expandedBracket === bracket.ticker}
+                  onToggle={() => setExpandedBracket(expandedBracket === bracket.ticker ? null : bracket.ticker)}
+                  isLeading={bracket.ticker === leadingBracket?.ticker}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="px-4 py-3 bg-white/5 border-t border-white/10">
+            <a
+              href={getKalshiUrl()}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 text-xs text-white/50 hover:text-white/70 transition-colors"
+            >
+              Trade on Kalshi
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+MarketBracketsModal.propTypes = {
+  brackets: PropTypes.array.isRequired,
+  cityName: PropTypes.string.isRequired,
+  seriesTicker: PropTypes.string.isRequired,
+  closeTime: PropTypes.instanceOf(Date),
+  dayOffset: PropTypes.number.isRequired,
+  onDayChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+/**
+ * BracketRow - Single bracket with expandable chart
+ */
+function BracketRow({ bracket, seriesTicker, isExpanded, onToggle, isLeading }) {
+  const [period, setPeriod] = useState('1h');
+
+  // Fetch candlesticks when expanded
+  const { candles, loading: candlesLoading } = useKalshiCandlesticks(
+    seriesTicker,
+    bracket.ticker,
+    period,
+    isExpanded
+  );
+
+  // Fetch orderbook when expanded
+  const { yesBids, noBids, loading: orderbookLoading } = useKalshiOrderbook(
+    bracket.ticker,
+    isExpanded
+  );
+
+  // Condense label (e.g., "38° to 39°" -> "38-39°")
+  const condenseLabel = (label) => {
+    const match = label.match(/(\d+)°?\s*to\s*(\d+)°?/i);
+    if (match) {
+      return `${match[1]}-${match[2]}°`;
+    }
+    return label;
+  };
+
+  return (
+    <div className={`border-b border-white/5 ${isExpanded ? 'bg-white/5' : ''}`}>
+      {/* Main Row - Clickable */}
+      <button
+        onClick={onToggle}
+        className={`w-full px-4 py-3 flex items-center justify-between hover:bg-white/5 transition-colors ${
+          isLeading ? 'bg-white/[0.03]' : ''
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <ChevronDown
+            className={`w-4 h-4 text-white/40 transition-transform ${
+              isExpanded ? '' : '-rotate-90'
+            }`}
+          />
+          <span className={`font-medium ${isLeading ? 'text-white' : 'text-white/80'}`}>
+            {condenseLabel(bracket.label)}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-4">
+          {/* Yes/No Prices */}
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-emerald-400">{bracket.yesPrice}¢</span>
+            <span className="text-white/30">/</span>
+            <span className="text-red-400">{bracket.noPrice}¢</span>
+          </div>
+
+          {/* Probability */}
+          <div className={`text-sm font-medium min-w-[40px] text-right ${
+            isLeading ? 'text-white' : 'text-white/70'
+          }`}>
+            {bracket.yesPrice}%
+          </div>
+        </div>
+      </button>
+
+      {/* Expanded Content */}
+      {isExpanded && (
+        <div className="px-4 pb-4 pt-2 border-t border-white/5">
+          {/* Period Toggle */}
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-xs text-white/50">Price History</span>
+            <div className="flex bg-white/10 rounded-lg p-0.5">
+              {['1h', '6h', '12h'].map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPeriod(p)}
+                  className={`px-2 py-1 text-[10px] font-medium rounded-md transition-all ${
+                    period === p
+                      ? 'bg-white/20 text-white'
+                      : 'text-white/50 hover:text-white/70'
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className="h-[150px] mb-3">
+            {candlesLoading ? (
+              <div className="h-full flex items-center justify-center">
+                <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
+              </div>
+            ) : candles.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-white/40 text-xs">
+                No price history available
+              </div>
+            ) : (
+              <PriceChart candles={candles} currentPrice={bracket.yesPrice} />
+            )}
+          </div>
+
+          {/* Orderbook Summary */}
+          <div className="grid grid-cols-2 gap-3">
+            <OrderbookSide
+              title="Yes Bids"
+              bids={yesBids.slice(0, 3)}
+              loading={orderbookLoading}
+              color="emerald"
+            />
+            <OrderbookSide
+              title="No Bids"
+              bids={noBids.slice(0, 3)}
+              loading={orderbookLoading}
+              color="red"
+            />
+          </div>
+
+          {/* Volume */}
+          <div className="mt-3 pt-3 border-t border-white/5 flex items-center justify-between text-xs text-white/40">
+            <span>Volume</span>
+            <span>{bracket.volume.toLocaleString()} contracts</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+BracketRow.propTypes = {
+  bracket: PropTypes.object.isRequired,
+  seriesTicker: PropTypes.string.isRequired,
+  isExpanded: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  isLeading: PropTypes.bool,
+};
+
+/**
+ * PriceChart - Line chart showing yes price over time
+ */
+function PriceChart({ candles, currentPrice }) {
+  // Prepare chart data with defensive checks
+  const chartData = useMemo(() => {
+    return candles
+      .filter(c => c && typeof c.timestamp === 'number' && c.timestamp > 0)
+      .map((c) => {
+        const price = typeof c.yesPrice === 'number' ? c.yesPrice :
+                      typeof c.close === 'number' ? c.close : 0;
+        const timeObj = c.time instanceof Date ? c.time : new Date(c.timestamp * 1000);
+
+        return {
+          time: c.timestamp,
+          timeLabel: timeObj.toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          }),
+          price: price,
+        };
+      })
+      .filter(d => d.price > 0);
+  }, [candles]);
+
+  // Calculate price range with safety checks
+  const prices = chartData.map((d) => d.price).filter((p) => typeof p === 'number' && p > 0);
+  const minPrice = prices.length > 0 ? Math.max(0, Math.min(...prices) - 5) : 0;
+  const maxPrice = prices.length > 0 ? Math.min(100, Math.max(...prices) + 5) : 100;
+
+  // Custom tooltip with safety checks
+  const CustomTooltip = ({ active, payload }) => {
+    if (!active || !payload || payload.length === 0) return null;
+    const data = payload[0]?.payload;
+    if (!data) return null;
+
+    const timeLabel = typeof data.timeLabel === 'string' ? data.timeLabel : '--';
+    const price = typeof data.price === 'number' ? data.price : 0;
+
+    return (
+      <div className="bg-black/80 backdrop-blur-sm px-2 py-1.5 rounded-lg text-xs border border-white/10">
+        <div className="text-white/60 mb-0.5">{timeLabel}</div>
+        <div className="text-white font-medium">{price}¢</div>
+      </div>
+    );
+  };
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+        <XAxis
+          dataKey="time"
+          type="number"
+          domain={['dataMin', 'dataMax']}
+          tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.4)' }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(ts) => {
+            const date = new Date(ts * 1000);
+            return date.toLocaleTimeString('en-US', {
+              hour: 'numeric',
+              minute: '2-digit',
+              hour12: true,
+            });
+          }}
+          interval="preserveStartEnd"
+          minTickGap={50}
+        />
+        <YAxis
+          domain={[minPrice, maxPrice]}
+          tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.4)' }}
+          tickLine={false}
+          axisLine={false}
+          width={30}
+          tickFormatter={(v) => `${v}¢`}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <ReferenceLine
+          y={currentPrice}
+          stroke="rgba(255,255,255,0.2)"
+          strokeDasharray="3 3"
+        />
+        <Line
+          type="monotone"
+          dataKey="price"
+          stroke="rgba(255, 255, 255, 0.8)"
+          strokeWidth={2}
+          dot={false}
+          activeDot={{ r: 4, fill: '#fff', stroke: 'rgba(255,255,255,0.4)', strokeWidth: 2 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+PriceChart.propTypes = {
+  candles: PropTypes.array.isRequired,
+  currentPrice: PropTypes.number,
+};
+
+/**
+ * OrderbookSide - Shows top bids for one side
+ */
+function OrderbookSide({ title, bids, loading, color }) {
+  const colorClass = color === 'emerald' ? 'text-emerald-400' : 'text-red-400';
+
+  return (
+    <div className="bg-white/5 rounded-lg p-2">
+      <div className="text-[10px] text-white/50 mb-1.5">{title}</div>
+      {loading ? (
+        <div className="space-y-1">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-4 bg-white/10 rounded animate-pulse" />
+          ))}
+        </div>
+      ) : bids.length === 0 ? (
+        <div className="text-[10px] text-white/30">No bids</div>
+      ) : (
+        <div className="space-y-0.5">
+          {bids.map((bid, idx) => (
+            <div key={idx} className="flex items-center justify-between text-[11px]">
+              <span className={colorClass}>{bid.price}¢</span>
+              <span className="text-white/50">{bid.quantity}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+OrderbookSide.propTypes = {
+  title: PropTypes.string.isRequired,
+  bids: PropTypes.array.isRequired,
+  loading: PropTypes.bool,
+  color: PropTypes.oneOf(['emerald', 'red']),
+};

--- a/src/hooks/useKalshiCandlesticks.js
+++ b/src/hooks/useKalshiCandlesticks.js
@@ -1,0 +1,160 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Kalshi API proxy endpoint
+ */
+const KALSHI_PROXY = '/api/kalshi';
+const KALSHI_PATH = 'trade-api/v2';
+
+/**
+ * Period intervals for candlestick data
+ * Kalshi only supports: 1 (1 min), 60 (1 hour), 1440 (1 day)
+ */
+export const PERIODS = {
+  '1h': 1,      // 1-minute candles for 1 hour view
+  '6h': 60,     // 1-hour candles for 6 hour view
+  '12h': 60,    // 1-hour candles for 12 hour view
+};
+
+/**
+ * Fetch candlestick data from Kalshi API
+ * @param {string} seriesTicker - Series ticker (e.g., "KXHIGHNY")
+ * @param {string} ticker - Full market ticker (e.g., "KXHIGHNY-25DEC29-B45")
+ * @param {number} periodInterval - Interval: 1 (1 min), 60 (1 hour), or 1440 (1 day)
+ * @param {number} hoursBack - How many hours of data to fetch
+ */
+async function fetchCandlesticks(seriesTicker, ticker, periodInterval = 1, hoursBack = 1) {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - hoursBack * 60 * 60 * 1000);
+
+  // Build URL with proper encoding
+  const params = new URLSearchParams({
+    path: `${KALSHI_PATH}/series/${seriesTicker}/markets/${ticker}/candlesticks`,
+    start_ts: Math.floor(startTime.getTime() / 1000).toString(),
+    end_ts: Math.floor(now.getTime() / 1000).toString(),
+    period_interval: periodInterval.toString(),
+  });
+
+  const url = `${KALSHI_PROXY}?${params.toString()}`;
+  console.log('[useKalshiCandlesticks] Fetching:', url);
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[useKalshiCandlesticks] API Error:', response.status, errorText);
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log('[useKalshiCandlesticks] Response:', data);
+  return data.candlesticks || [];
+}
+
+/**
+ * Hook to fetch Kalshi candlestick data for price history charts
+ * @param {string} seriesTicker - Series ticker (e.g., "KXHIGHNY")
+ * @param {string} ticker - Full market ticker
+ * @param {string} period - Period key: '1h', '6h', or '12h'
+ * @param {boolean} enabled - Whether to fetch data
+ */
+export function useKalshiCandlesticks(seriesTicker, ticker, period = '1h', enabled = true) {
+  const [candles, setCandles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const periodInterval = PERIODS[period] || 1;
+
+  const fetchData = useCallback(async () => {
+    if (!seriesTicker || !ticker || !enabled) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    // Determine hours back based on period
+    let hoursBack = 1;
+    if (period === '6h') hoursBack = 6;
+    if (period === '12h') hoursBack = 12;
+
+    try {
+      const rawCandles = await fetchCandlesticks(seriesTicker, ticker, periodInterval, hoursBack);
+
+      // Ensure we have an array
+      if (!Array.isArray(rawCandles)) {
+        console.warn('[useKalshiCandlesticks] Response is not an array:', rawCandles);
+        setCandles([]);
+        return;
+      }
+
+      // Transform candlestick data for chart
+      // Kalshi API returns: { end_period_ts, yes_bid: {open,high,low,close}, yes_ask: {...}, price: {...}, volume }
+      const transformed = rawCandles.map(c => {
+        // Get timestamp
+        const ts = c.end_period_ts || c.ts || 0;
+
+        // Extract price from nested OHLC objects
+        // Priority: yes_bid.close (current bid price) > price.close > price.mean
+        let yesPrice = 0;
+
+        // Try yes_bid first (this is the YES buy price)
+        if (c.yes_bid && typeof c.yes_bid === 'object') {
+          yesPrice = c.yes_bid.close || c.yes_bid.mean || c.yes_bid.open || 0;
+        }
+
+        // Fallback to price object (trade price)
+        if (yesPrice === 0 && c.price && typeof c.price === 'object') {
+          yesPrice = c.price.close || c.price.mean || c.price.open || 0;
+        }
+
+        // Get OHLC from yes_bid or price
+        const ohlcSource = c.yes_bid || c.price || {};
+        const open = typeof ohlcSource.open === 'number' ? ohlcSource.open : 0;
+        const high = typeof ohlcSource.high === 'number' ? ohlcSource.high : 0;
+        const low = typeof ohlcSource.low === 'number' ? ohlcSource.low : 0;
+        const close = typeof ohlcSource.close === 'number' ? ohlcSource.close : yesPrice;
+
+        return {
+          time: new Date(ts * 1000),
+          timestamp: ts,
+          open,
+          high,
+          low,
+          close,
+          yesPrice: yesPrice || close,
+          volume: typeof c.volume === 'number' ? c.volume : 0,
+        };
+      });
+
+      // Sort by time ascending and filter out invalid entries
+      transformed.sort((a, b) => a.timestamp - b.timestamp);
+
+      // Filter to only valid candles with timestamps and prices
+      const validCandles = transformed.filter(c =>
+        c.timestamp > 0 && c.yesPrice > 0 && !isNaN(c.timestamp)
+      );
+
+      setCandles(validCandles);
+    } catch (err) {
+      console.error('[useKalshiCandlesticks] Error:', err);
+      setError(err.message);
+      setCandles([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [seriesTicker, ticker, periodInterval, period, enabled]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    candles,
+    loading,
+    error,
+    refetch: fetchData,
+  };
+}
+
+export default useKalshiCandlesticks;

--- a/src/hooks/useKalshiOrderbook.js
+++ b/src/hooks/useKalshiOrderbook.js
@@ -1,0 +1,95 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Kalshi API proxy endpoint
+ */
+const KALSHI_PROXY = '/api/kalshi';
+const KALSHI_PATH = 'trade-api/v2';
+
+/**
+ * Fetch orderbook data from Kalshi API
+ * @param {string} ticker - Full market ticker (e.g., "KXHIGHNY-25DEC29-B45")
+ */
+async function fetchOrderbook(ticker) {
+  const url = `${KALSHI_PROXY}?path=${KALSHI_PATH}/markets/${ticker}/orderbook`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.orderbook || data;
+}
+
+/**
+ * Hook to fetch Kalshi orderbook data for a market
+ * @param {string} ticker - Full market ticker
+ * @param {boolean} enabled - Whether to fetch data
+ */
+export function useKalshiOrderbook(ticker, enabled = true) {
+  const [orderbook, setOrderbook] = useState({ yesBids: [], noBids: [] });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchData = useCallback(async () => {
+    if (!ticker || !enabled) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchOrderbook(ticker);
+
+      // Parse orderbook data
+      // Kalshi returns yes_bids and no_bids (or similar structure)
+      const yesBids = (data.yes || []).map(order => ({
+        price: order[0], // Price in cents
+        quantity: order[1], // Number of contracts
+      })).sort((a, b) => b.price - a.price); // Sort by price descending
+
+      const noBids = (data.no || []).map(order => ({
+        price: order[0],
+        quantity: order[1],
+      })).sort((a, b) => b.price - a.price);
+
+      setOrderbook({ yesBids, noBids });
+    } catch (err) {
+      console.error('[useKalshiOrderbook] Error:', err);
+      setError(err.message);
+      setOrderbook({ yesBids: [], noBids: [] });
+    } finally {
+      setLoading(false);
+    }
+  }, [ticker, enabled]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Calculate best bid/ask
+  const bestYesBid = orderbook.yesBids[0]?.price || null;
+  const bestNoBid = orderbook.noBids[0]?.price || null;
+
+  // Calculate total depth
+  const totalYesDepth = orderbook.yesBids.reduce((sum, o) => sum + o.quantity, 0);
+  const totalNoDepth = orderbook.noBids.reduce((sum, o) => sum + o.quantity, 0);
+
+  return {
+    orderbook,
+    yesBids: orderbook.yesBids,
+    noBids: orderbook.noBids,
+    bestYesBid,
+    bestNoBid,
+    totalYesDepth,
+    totalNoDepth,
+    loading,
+    error,
+    refetch: fetchData,
+  };
+}
+
+export default useKalshiOrderbook;

--- a/src/styles/liquid-glass.css
+++ b/src/styles/liquid-glass.css
@@ -120,10 +120,10 @@ body {
 
 /* Elevated glass (modals, popovers) */
 .glass-elevated {
-  background: var(--glass-bg-elevated);
-  backdrop-filter: blur(var(--glass-blur-heavy)) saturate(200%);
-  -webkit-backdrop-filter: blur(var(--glass-blur-heavy)) saturate(200%);
-  border: 1px solid var(--glass-border-strong);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur-heavy)) saturate(180%);
+  -webkit-backdrop-filter: blur(var(--glass-blur-heavy)) saturate(180%);
+  border: none;
   border-radius: var(--radius-xl);
   box-shadow: var(--glass-shadow-elevated), var(--glass-inner-highlight);
 }


### PR DESCRIPTION
## Summary
- Add expandable detail modal when clicking the Market Brackets widget
- Each bracket row shows temperature range, yes/no prices, and volume
- Click a bracket to expand and view historical price chart (1hr, 6hr, 12hr toggles)
- Orderbook summary shows bid/ask depth
- Sort brackets by temperature (lowest to highest)
- Update widget header styling to match other widgets

## New Files
- `src/components/weather/MarketBracketsModal.jsx` - Detail modal component
- `src/hooks/useKalshiCandlesticks.js` - Historical price data hook
- `src/hooks/useKalshiOrderbook.js` - Orderbook data hook

## Test plan
- [ ] Click Market Brackets widget to open modal
- [ ] Verify brackets sorted lowest to highest temperature
- [ ] Click bracket row to expand price chart
- [ ] Toggle between 1hr, 6hr, 12hr periods
- [ ] Verify modal closes on backdrop click or X button
- [ ] Verify "Trade on Kalshi" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)