### PR TITLE
Redesign homepage as markets dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import { NotesSidebarProvider } from './context/NotesSidebarContext';
 import { KalshiMarketsProvider } from './hooks/useAllKalshiMarkets';
 import DynamicBackground from './components/layout/DynamicBackground';
 import GlassSidebar from './components/layout/GlassSidebar';
-import HomePageNew from './components/home/HomePageNew';
+import HomePageMarkets from './components/home/HomePageMarkets';
 import CityDashboardNew from './components/dashboard/CityDashboardNew';
 import ResearchLogPageNew from './components/research/ResearchLogPageNew';
 import ResearchNotePage from './components/research/ResearchNotePage';
@@ -28,7 +28,7 @@ function App() {
                   {/* Main content area - offset for sidebar on desktop */}
                   <main className="flex-1 ml-0 md:ml-[19rem] transition-all duration-300 w-full max-w-full overflow-x-hidden">
                     <Routes>
-                      <Route path="/" element={<HomePageNew />} />
+                      <Route path="/" element={<HomePageMarkets />} />
                       <Route path="/research" element={<ResearchLogPageNew />} />
                       <Route path="/research/:noteType/:slug" element={<ResearchNotePage />} />
                       <Route path="/city/:citySlug" element={<CityDashboardNew />} />

--- a/src/components/home/AggregateStats.jsx
+++ b/src/components/home/AggregateStats.jsx
@@ -1,0 +1,123 @@
+import { useState, useEffect, useContext } from 'react';
+import { DollarSign, Activity, Clock } from 'lucide-react';
+import { KalshiMarketsContext } from '../../hooks/useAllKalshiMarkets.jsx';
+
+/**
+ * AggregateStats - Summary statistics across all markets
+ * Shows total volume, active markets, and time until next close
+ */
+export default function AggregateStats() {
+  const context = useContext(KalshiMarketsContext);
+  const [nextCloseTimer, setNextCloseTimer] = useState(null);
+
+  const { marketsData = {}, loading } = context || {};
+
+  // Calculate aggregate stats
+  const totalVolume = Object.values(marketsData).reduce(
+    (sum, m) => sum + (m.totalVolume || 0),
+    0
+  );
+
+  const activeMarkets = Object.values(marketsData).filter(
+    (m) => m.brackets?.length > 0 && !m.error
+  ).length;
+
+  const nextCloseTime = Object.values(marketsData)
+    .map((m) => m.closeTime)
+    .filter(Boolean)
+    .sort((a, b) => a.getTime() - b.getTime())[0];
+
+  // Update countdown timer for next market close
+  useEffect(() => {
+    const updateTimer = () => {
+      if (!nextCloseTime) {
+        setNextCloseTimer(null);
+        return;
+      }
+
+      const now = new Date();
+      const diff = nextCloseTime.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        setNextCloseTimer('Closed');
+        return;
+      }
+
+      const hours = Math.floor(diff / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      setNextCloseTimer(`${hours}h ${minutes}m`);
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 60000); // Update every minute
+    return () => clearInterval(interval);
+  }, [nextCloseTime]);
+
+  const formatVolume = (vol) => {
+    if (!vol) return '--';
+    if (vol >= 1000000) return `$${(vol / 1000000).toFixed(1)}M`;
+    if (vol >= 1000) return `$${Math.round(vol / 1000)}K`;
+    return `$${vol.toLocaleString()}`;
+  };
+
+  if (loading) {
+    return (
+      <div className="w-full max-w-6xl mx-auto px-4 mt-6">
+        <div className="grid grid-cols-3 gap-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="glass-widget p-4 animate-pulse">
+              <div className="h-3 w-16 bg-white/10 rounded mb-2" />
+              <div className="h-6 w-20 bg-white/10 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-6xl mx-auto px-4 mt-6">
+      <div className="grid grid-cols-3 gap-3">
+        {/* Total Volume */}
+        <div className="glass-widget p-4">
+          <div className="flex items-center gap-1.5 mb-1">
+            <DollarSign className="w-3 h-3 text-white/50" />
+            <span className="text-[10px] text-white/50 uppercase tracking-wide font-medium">
+              Total Volume
+            </span>
+          </div>
+          <div className="text-xl font-bold text-white">
+            {formatVolume(totalVolume)}
+          </div>
+        </div>
+
+        {/* Active Markets */}
+        <div className="glass-widget p-4">
+          <div className="flex items-center gap-1.5 mb-1">
+            <Activity className="w-3 h-3 text-white/50" />
+            <span className="text-[10px] text-white/50 uppercase tracking-wide font-medium">
+              Active Markets
+            </span>
+          </div>
+          <div className="text-xl font-bold text-white">
+            {activeMarkets}
+            <span className="text-sm text-white/50 font-normal">/7</span>
+          </div>
+        </div>
+
+        {/* Next Close */}
+        <div className="glass-widget p-4">
+          <div className="flex items-center gap-1.5 mb-1">
+            <Clock className="w-3 h-3 text-white/50" />
+            <span className="text-[10px] text-white/50 uppercase tracking-wide font-medium">
+              Next Close
+            </span>
+          </div>
+          <div className="text-xl font-bold text-orange-400 tabular-nums">
+            {nextCloseTimer || '--'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/AllMarketsModal.jsx
+++ b/src/components/home/AllMarketsModal.jsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { X, TrendingUp, CloudRain, Snowflake } from 'lucide-react';
+
+/**
+ * AllMarketsModal - Popup showing all markets in a category
+ * Displays condensed market cards in a scrollable grid
+ */
+export default function AllMarketsModal({
+  isOpen,
+  onClose,
+  title,
+  icon: Icon = TrendingUp,
+  markets = [],
+  type = 'temperature'
+}) {
+  const [timer, setTimer] = useState({});
+
+  // Update timers every second
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updateTimers = () => {
+      const newTimers = {};
+      markets.forEach(market => {
+        if (market.closeTime) {
+          const now = new Date();
+          const diff = market.closeTime.getTime() - now.getTime();
+          if (diff <= 0) {
+            newTimers[market.slug] = 'Closed';
+          } else {
+            const hours = Math.floor(diff / (1000 * 60 * 60));
+            const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+            newTimers[market.slug] = `${hours}h ${minutes}m`;
+          }
+        }
+      });
+      setTimer(newTimers);
+    };
+
+    updateTimers();
+    const interval = setInterval(updateTimers, 60000);
+    return () => clearInterval(interval);
+  }, [isOpen, markets]);
+
+  const formatVolume = (vol) => {
+    if (!vol) return '--';
+    if (vol >= 1000000) return `$${(vol / 1000000).toFixed(1)}M`;
+    if (vol >= 1000) return `$${Math.round(vol / 1000)}K`;
+    return `$${vol.toLocaleString()}`;
+  };
+
+  // Condense bracket label
+  const condenseLabel = (label) => {
+    if (!label) return '';
+    return label
+      .replace(/(\d+)°\s*(to|or)\s*(\d+)°/i, '$1-$3°')
+      .replace(/(\d+)°\s*or above/i, '≥$1°')
+      .replace(/(\d+)°\s*or below/i, '≤$1°');
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[90]"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="fixed inset-4 md:inset-8 lg:inset-16 z-[100] flex items-center justify-center">
+        <div className="glass-elevated w-full max-w-4xl max-h-full overflow-hidden flex flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between p-4 border-b border-white/10">
+            <div className="flex items-center gap-2">
+              <Icon className="w-5 h-5 text-white/70" />
+              <h2 className="text-lg font-semibold text-white">{title}</h2>
+              <span className="text-sm text-white/50">({markets.length} markets)</span>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-full hover:bg-white/10 transition-colors"
+            >
+              <X className="w-5 h-5 text-white/70" />
+            </button>
+          </div>
+
+          {/* Markets Grid */}
+          <div className="flex-1 overflow-y-auto p-4">
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {markets.map((market) => (
+                <Link
+                  key={market.slug}
+                  to={`/city/${market.slug}`}
+                  onClick={onClose}
+                  className="glass-widget p-3 hover:bg-white/10 transition-colors"
+                >
+                  {/* City Name & Timer */}
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="font-medium text-white">{market.name}</span>
+                    <span className="text-xs text-orange-400 tabular-nums">
+                      {timer[market.slug] || '--'}
+                    </span>
+                  </div>
+
+                  {/* Top Bracket */}
+                  {market.topBrackets?.[0] && (
+                    <div className="flex items-center justify-between text-sm mb-1">
+                      <span className="text-white/60">
+                        {condenseLabel(market.topBrackets[0].label)}
+                      </span>
+                      <span className="font-bold text-white tabular-nums">
+                        {market.topBrackets[0].yesPrice}%
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Volume */}
+                  <div className="text-xs text-white/40 mt-2">
+                    {formatVolume(market.totalVolume)} volume
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="p-4 border-t border-white/10 text-center">
+            <p className="text-xs text-white/40">
+              Click any market to view detailed forecasts and data
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/home/HomePageMarkets.jsx
+++ b/src/components/home/HomePageMarkets.jsx
@@ -1,0 +1,253 @@
+import { useState, useContext, useMemo } from 'react';
+import { TrendingUp, CloudRain, Snowflake, ChevronRight } from 'lucide-react';
+import { MARKET_CITIES } from '../../config/cities';
+import { KalshiMarketsContext } from '../../hooks/useAllKalshiMarkets.jsx';
+import { useKalshiRainMarkets, RAIN_CITIES } from '../../hooks/useKalshiRainMarkets';
+import { useKalshiSnowMarkets, SNOW_CITIES } from '../../hooks/useKalshiSnowMarkets';
+import MarketCardGlass from './MarketCardGlass';
+import AllMarketsModal from './AllMarketsModal';
+
+/**
+ * HomePageMarkets - Markets-focused homepage
+ * Displays top 3 markets by volume for each category with "Show more"
+ */
+export default function HomePageMarkets() {
+  const context = useContext(KalshiMarketsContext);
+  const { loading: tempLoading, lastFetch, marketsData = {} } = context || {};
+
+  // Fetch rain and snow markets
+  const { markets: rainMarketsData, loading: rainLoading } = useKalshiRainMarkets();
+  const { markets: snowMarketsData, loading: snowLoading } = useKalshiSnowMarkets();
+
+  // Modal state
+  const [tempModalOpen, setTempModalOpen] = useState(false);
+  const [rainModalOpen, setRainModalOpen] = useState(false);
+  const [snowModalOpen, setSnowModalOpen] = useState(false);
+
+  // Sort cities by volume and get top 3
+  const sortedTempMarkets = useMemo(() => {
+    return MARKET_CITIES
+      .map(city => ({
+        ...city,
+        ...marketsData[city.slug],
+      }))
+      .sort((a, b) => (b.totalVolume || 0) - (a.totalVolume || 0));
+  }, [marketsData]);
+
+  const top3TempMarkets = sortedTempMarkets.slice(0, 3);
+
+  // Format last update time
+  const formatLastUpdate = () => {
+    if (!lastFetch) return null;
+    return lastFetch.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  // Use real rain markets data, sorted by volume
+  const rainMarkets = useMemo(() => {
+    return rainMarketsData.length > 0 ? rainMarketsData : [];
+  }, [rainMarketsData]);
+
+  // Use real snow markets data, sorted by volume
+  const snowMarkets = useMemo(() => {
+    return snowMarketsData.length > 0 ? snowMarketsData : [];
+  }, [snowMarketsData]);
+
+  // Check if there are no active rain/snow markets
+  const noRainMarkets = !rainLoading && rainMarkets.length === 0;
+  const noSnowMarkets = !snowLoading && snowMarkets.length === 0;
+
+  return (
+    <div className="min-h-screen pb-24 md:pb-8 overflow-x-hidden w-full max-w-[100vw]">
+      {/* Hero Section */}
+      <div className="w-full max-w-6xl mx-auto px-4 pt-8 pb-4">
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+              Weather Markets
+            </h1>
+            <p className="text-sm text-white/60">
+              Real-time prediction markets on Kalshi
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            {/* Live indicator */}
+            <div className="glass-badge flex items-center gap-2">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+              </span>
+              <span className="text-white/80 text-xs font-medium">Live</span>
+            </div>
+            {lastFetch && (
+              <span className="text-[10px] text-white/40 hidden sm:block">
+                Updated {formatLastUpdate()}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Temperature Markets Section */}
+      <MarketSection
+        title="Temperature Markets"
+        subtitle="Highest temperature predictions"
+        icon={TrendingUp}
+        markets={top3TempMarkets}
+        allMarkets={sortedTempMarkets}
+        loading={tempLoading}
+        onShowMore={() => setTempModalOpen(true)}
+        totalCount={MARKET_CITIES.length}
+      />
+
+      {/* Rain Markets Section */}
+      <MarketSection
+        title="Rain Markets"
+        subtitle="Precipitation predictions"
+        icon={CloudRain}
+        markets={rainMarkets.slice(0, 3)}
+        allMarkets={rainMarkets}
+        loading={rainLoading}
+        onShowMore={() => setRainModalOpen(true)}
+        totalCount={RAIN_CITIES.length}
+        noActiveMarkets={noRainMarkets}
+      />
+
+      {/* Snow Markets Section */}
+      <MarketSection
+        title="Snow Markets"
+        subtitle="Snowfall predictions"
+        icon={Snowflake}
+        markets={snowMarkets.slice(0, 3)}
+        allMarkets={snowMarkets}
+        loading={snowLoading}
+        onShowMore={() => setSnowModalOpen(true)}
+        totalCount={SNOW_CITIES.length}
+        noActiveMarkets={noSnowMarkets}
+      />
+
+      {/* Footer */}
+      <div className="w-full max-w-6xl mx-auto px-4 mt-8 text-center">
+        <p className="text-xs text-white/30">
+          Data provided by{' '}
+          <a
+            href="https://kalshi.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white/50 hover:text-white/70 transition-colors"
+          >
+            Kalshi
+          </a>
+        </p>
+      </div>
+
+      {/* Modals */}
+      <AllMarketsModal
+        isOpen={tempModalOpen}
+        onClose={() => setTempModalOpen(false)}
+        title="All Temperature Markets"
+        icon={TrendingUp}
+        markets={sortedTempMarkets}
+        type="temperature"
+      />
+      <AllMarketsModal
+        isOpen={rainModalOpen}
+        onClose={() => setRainModalOpen(false)}
+        title="All Rain Markets"
+        icon={CloudRain}
+        markets={rainMarkets}
+        type="rain"
+      />
+      <AllMarketsModal
+        isOpen={snowModalOpen}
+        onClose={() => setSnowModalOpen(false)}
+        title="All Snow Markets"
+        icon={Snowflake}
+        markets={snowMarkets}
+        type="snow"
+      />
+    </div>
+  );
+}
+
+/**
+ * MarketSection - Reusable section for a market category
+ */
+function MarketSection({
+  title,
+  subtitle,
+  icon: Icon,
+  markets,
+  allMarkets,
+  loading,
+  onShowMore,
+  totalCount,
+  noActiveMarkets = false
+}) {
+  return (
+    <div className="w-full max-w-6xl mx-auto px-4 mt-6">
+      {/* Section Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Icon className="w-4 h-4 text-white/60" />
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          {noActiveMarkets && (
+            <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/10 text-white/50">
+              No Active Markets
+            </span>
+          )}
+        </div>
+        {!noActiveMarkets && markets.length > 0 && (
+          <button
+            onClick={onShowMore}
+            className="flex items-center gap-1 text-xs text-white/50 hover:text-white/80 transition-colors"
+          >
+            Show all {totalCount}
+            <ChevronRight className="w-3 h-3" />
+          </button>
+        )}
+      </div>
+      <p className="text-xs text-white/40 mb-4">{subtitle}</p>
+
+      {/* Markets Grid */}
+      {loading ? (
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {[...Array(Math.min(3, totalCount))].map((_, i) => (
+            <div key={i} className="glass-widget animate-pulse">
+              <div className="h-20 bg-white/10" />
+              <div className="p-3">
+                <div className="h-3 w-32 bg-white/10 rounded mb-3" />
+                <div className="space-y-2 mb-3">
+                  <div className="h-9 bg-white/10 rounded-lg" />
+                  <div className="h-9 bg-white/10 rounded-lg" />
+                </div>
+                <div className="flex justify-between pt-2 border-t border-white/10">
+                  <div className="h-3 w-12 bg-white/10 rounded" />
+                  <div className="h-3 w-16 bg-white/10 rounded" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : noActiveMarkets ? (
+        <div className="glass-widget p-8 text-center">
+          <Icon className="w-8 h-8 text-white/30 mx-auto mb-3" />
+          <p className="text-sm text-white/50">No active markets at this time</p>
+          <p className="text-xs text-white/30 mt-1">Check back later for new markets</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {markets.map((market, index) => (
+            <MarketCardGlass
+              key={market.slug}
+              city={market}
+              index={index}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/home/MarketCardGlass.jsx
+++ b/src/components/home/MarketCardGlass.jsx
@@ -1,0 +1,176 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useKalshiMarketsFromContext } from '../../hooks/useAllKalshiMarkets.jsx';
+import { CITY_BY_SLUG } from '../../config/cities';
+
+/**
+ * MarketCardGlass - Glass-styled market card for homepage
+ * Displays city market data with probability bars and countdown timer
+ */
+export default function MarketCardGlass({ city, index = 0, comingSoon = false }) {
+  // Get market data from context if it's a temperature market, otherwise use passed data
+  const contextData = useKalshiMarketsFromContext(city.slug);
+
+  // Use context data for temp markets, or passed data for rain/snow
+  const topBrackets = city.topBrackets || contextData.topBrackets || [];
+  const totalVolume = city.totalVolume ?? contextData.totalVolume;
+  const closeTime = city.closeTime || contextData.closeTime;
+  const loading = contextData.loading && !city.topBrackets;
+  const error = contextData.error && !city.topBrackets;
+
+  // Get city image from config if not passed
+  const cityConfig = CITY_BY_SLUG[city.slug];
+  const cityImage = city.image || cityConfig?.image;
+
+  const [timer, setTimer] = useState(null);
+
+  // Update timer every second based on market close time
+  useEffect(() => {
+    const updateTimer = () => {
+      if (!closeTime) {
+        setTimer(null);
+        return;
+      }
+
+      const now = new Date();
+      const closeDate = closeTime instanceof Date ? closeTime : new Date(closeTime);
+      const diff = closeDate.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        setTimer({ hours: 0, minutes: 0, seconds: 0, formatted: 'Closed' });
+        return;
+      }
+
+      const hours = Math.floor(diff / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+      setTimer({ hours, minutes, seconds, formatted: `${hours}h ${minutes}m ${seconds}s` });
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+    return () => clearInterval(interval);
+  }, [closeTime]);
+
+  const formatVolume = (vol) => {
+    if (!vol) return '--';
+    if (vol >= 1000000) return `$${(vol / 1000000).toFixed(1)}M`;
+    if (vol >= 1000) return `$${Math.round(vol / 1000)}K`;
+    return `$${vol.toLocaleString()}`;
+  };
+
+  // Condense label: "39° to 40°" -> "39-40°"
+  const condenseLabel = (label) => {
+    if (!label) return '';
+    return label
+      .replace(/(\d+)°\s*(to|or)\s*(\d+)°/i, '$1-$3°')
+      .replace(/(\d+)°\s*or above/i, '≥$1°')
+      .replace(/(\d+)°\s*or below/i, '≤$1°');
+  };
+
+  // Staggered animation delay
+  const animationDelay = `glass-delay-${(index % 5) + 1}`;
+
+  return (
+    <Link
+      to={`/city/${city.slug}`}
+      className={`
+        glass-widget glass-interactive glass-animate-in ${animationDelay}
+        block overflow-hidden
+        ${comingSoon ? 'opacity-60 pointer-events-none' : ''}
+      `}
+    >
+      {/* City Image Header */}
+      <div className="relative h-20 overflow-hidden bg-gradient-to-br from-blue-900/50 to-purple-900/50">
+        {cityImage && (
+          <img
+            src={cityImage.replace('w=200&h=200', 'w=400&h=200')}
+            alt={city.name}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+        <h3 className="absolute bottom-2 left-3 text-white font-semibold text-lg drop-shadow-lg">
+          {city.name}
+        </h3>
+        {comingSoon && (
+          <div className="absolute top-2 right-2">
+            <span className="text-[9px] px-2 py-0.5 rounded-full bg-black/50 text-white/70">
+              Coming Soon
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Card Content */}
+      <div className="p-3">
+        {/* Brackets */}
+        {loading ? (
+          <div className="space-y-2 mb-3">
+            <div className="h-9 bg-white/10 rounded-lg animate-pulse" />
+            <div className="h-9 bg-white/10 rounded-lg animate-pulse" />
+          </div>
+        ) : error ? (
+          <div className="h-[72px] flex items-center justify-center text-xs text-white/40 mb-3">
+            {error}
+          </div>
+        ) : topBrackets.length > 0 ? (
+          <div className="space-y-1.5 mb-3">
+            {topBrackets.slice(0, 2).map((bracket, i) => (
+              <div
+                key={bracket.ticker || i}
+                className="relative flex items-center justify-between py-2 px-2 rounded-lg"
+              >
+                {/* Probability bar background */}
+                <div
+                  className="absolute left-0 top-0 bottom-0 rounded-lg opacity-25"
+                  style={{
+                    width: `${bracket.yesPrice}%`,
+                    backgroundColor: '#3B82F6',
+                  }}
+                />
+
+                {/* Label */}
+                <span className="relative text-sm font-medium text-white/80">
+                  {condenseLabel(bracket.label)}
+                </span>
+
+                {/* Price and Yes/No */}
+                <div className="relative flex items-center gap-2">
+                  <span className="text-sm font-bold text-white tabular-nums">
+                    {bracket.yesPrice}%
+                  </span>
+                  <div className="flex rounded-md overflow-hidden text-[10px] font-medium">
+                    <span className="px-2 py-1 bg-purple-500/20 text-purple-400">
+                      Yes
+                    </span>
+                    <span className="px-2 py-1 bg-white/10 text-white/50">
+                      No
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="h-[72px] flex items-center justify-center text-xs text-white/40 mb-3">
+            No markets available
+          </div>
+        )}
+
+        {/* Footer with volume and timer */}
+        <div className="flex items-center justify-between pt-2 border-t border-white/10">
+          <span className="text-xs text-white/50">
+            {formatVolume(totalVolume)}
+          </span>
+          {timer && (
+            <span className="text-xs font-medium text-orange-400 tabular-nums">
+              {timer.formatted}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/config/cities.js
+++ b/src/config/cities.js
@@ -9,7 +9,7 @@ const CITY_IMAGES = {
   'chicago': 'https://images.unsplash.com/photo-1494522855154-9297ac14b55f?w=200&h=200&fit=crop',
   'los-angeles': 'https://images.unsplash.com/photo-1534190760961-74e8c1c5c3da?w=200&h=200&fit=crop',
   'miami': 'https://images.unsplash.com/photo-1533106497176-45ae19e68ba2?w=200&h=200&fit=crop',
-  'denver': 'https://images.unsplash.com/photo-1619856699906-09e1f58c98b1?w=200&h=200&fit=crop',
+  'denver': 'https://images.unsplash.com/photo-1546156929-a4c0ac411f47?w=200&h=200&fit=crop',
   'austin': 'https://images.unsplash.com/photo-1531218150217-54595bc2b934?w=200&h=200&fit=crop',
   'philadelphia': 'https://images.unsplash.com/photo-1569761316261-9a8696fa2ca3?w=200&h=200&fit=crop',
   'houston': 'https://images.unsplash.com/photo-1530089711124-9ca31fb9e863?w=200&h=200&fit=crop',

--- a/src/hooks/useAllKalshiMarkets.jsx
+++ b/src/hooks/useAllKalshiMarkets.jsx
@@ -211,4 +211,4 @@ export function useKalshiMarketsFromContext(citySlug) {
   };
 }
 
-export { CITY_SERIES };
+export { CITY_SERIES, KalshiMarketsContext };

--- a/src/hooks/useKalshiRainMarkets.js
+++ b/src/hooks/useKalshiRainMarkets.js
@@ -1,0 +1,257 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Kalshi API - uses proxy to bypass CORS
+ */
+const KALSHI_PROXY = '/api/kalshi';
+const KALSHI_PATH = 'trade-api/v2';
+
+/**
+ * Rain market series tickers
+ * NYC has both monthly accumulation and daily rain markets
+ */
+export const RAIN_SERIES = {
+  // Monthly rain accumulation (Above X inches)
+  nycMonthly: 'KXNYCRAINM',
+  // Daily will it rain (Yes/No)
+  nycDaily: 'KXRAINNYC',
+};
+
+/**
+ * City metadata for rain markets
+ * Currently only NYC has rain markets
+ */
+export const RAIN_CITIES = [
+  { slug: 'new-york', name: 'New York', id: 'NYC', type: 'monthly' },
+  { slug: 'new-york-daily', name: 'NYC Daily', id: 'NYC-D', type: 'daily' },
+];
+
+/**
+ * Get current month's date suffix for Kalshi ticker (e.g., "25DEC" for Dec 2025)
+ */
+function getCurrentMonthSuffix() {
+  const now = new Date();
+  const year = now.getFullYear().toString().slice(-2);
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+  const month = months[now.getMonth()];
+  return `${year}${month}`;
+}
+
+/**
+ * Get today's date in Kalshi ticker format (e.g., "25DEC29" for Dec 29, 2025)
+ */
+function getTodayTickerDate() {
+  const now = new Date();
+  const year = now.getFullYear().toString().slice(-2);
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+  const month = months[now.getMonth()];
+  const day = now.getDate().toString().padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+/**
+ * Fetch markets for a series
+ */
+async function fetchMarkets(seriesTicker) {
+  const url = `${KALSHI_PROXY}?path=${KALSHI_PATH}/markets&series_ticker=${seriesTicker}&limit=50`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.markets || [];
+}
+
+/**
+ * Process monthly rain market data (accumulation brackets)
+ */
+function processMonthlyRainMarkets(markets) {
+  if (!markets || markets.length === 0) return null;
+
+  const currentMonth = getCurrentMonthSuffix();
+
+  // Filter for current month's active markets
+  const currentMarkets = markets.filter(m =>
+    m.ticker.includes(`-${currentMonth}`) && m.status === 'active'
+  );
+
+  if (currentMarkets.length === 0) {
+    const activeMarkets = markets.filter(m => m.status === 'active');
+    if (activeMarkets.length === 0) return null;
+    return processMarketList(activeMarkets, 'Rain in NYC this month?');
+  }
+
+  return processMarketList(currentMarkets, 'Rain in NYC this month?');
+}
+
+/**
+ * Process daily rain market data (binary Yes/No)
+ */
+function processDailyRainMarkets(markets) {
+  if (!markets || markets.length === 0) return null;
+
+  const todayDate = getTodayTickerDate();
+
+  // Filter for today's market
+  const todayMarkets = markets.filter(m =>
+    m.ticker.includes(`-${todayDate}`) && m.status === 'active'
+  );
+
+  if (todayMarkets.length === 0) {
+    const activeMarkets = markets.filter(m => m.status === 'active');
+    if (activeMarkets.length === 0) return null;
+    // Use the most recent active market
+    const sorted = activeMarkets.sort((a, b) =>
+      new Date(b.close_time || 0) - new Date(a.close_time || 0)
+    );
+    return processDailyMarket(sorted[0]);
+  }
+
+  return processDailyMarket(todayMarkets[0]);
+}
+
+/**
+ * Process a list of monthly markets into displayable format
+ */
+function processMarketList(markets, title) {
+  // Sort by yes_bid price descending to get top brackets
+  const sorted = [...markets].sort((a, b) => (b.yes_bid || 0) - (a.yes_bid || 0));
+
+  // Calculate total volume
+  const totalVolume = markets.reduce((sum, m) => sum + (m.volume || 0), 0);
+
+  // Get close time from first market
+  const closeTime = sorted[0]?.close_time ? new Date(sorted[0].close_time) : null;
+
+  // Extract top 2 brackets
+  const topBrackets = sorted.slice(0, 2).map(m => {
+    let label = m.subtitle || m.yes_sub_title || 'Rain';
+    // Condense label: "Above 4 inches" -> "≥4""
+    label = label.replace(/Above\s+/i, '≥').replace(/\s+inches?/i, '"').replace(/\s+inch/i, '"');
+
+    return {
+      label,
+      yesPrice: m.yes_bid || 0,
+      ticker: m.ticker,
+    };
+  });
+
+  return {
+    topBrackets,
+    totalVolume,
+    closeTime,
+    title,
+  };
+}
+
+/**
+ * Process a single daily rain market
+ */
+function processDailyMarket(market) {
+  if (!market) return null;
+
+  const yesPrice = market.yes_bid || 0;
+  const closeTime = market.close_time ? new Date(market.close_time) : null;
+
+  return {
+    topBrackets: [{
+      label: 'Will it rain?',
+      yesPrice,
+      ticker: market.ticker,
+    }],
+    totalVolume: market.volume || 0,
+    closeTime,
+    title: 'Will it rain in NYC today?',
+  };
+}
+
+/**
+ * Hook to fetch all rain markets
+ */
+export function useKalshiRainMarkets() {
+  const [marketsData, setMarketsData] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [lastFetch, setLastFetch] = useState(null);
+
+  const fetchAllRainMarkets = useCallback(async () => {
+    const results = {};
+
+    // Fetch monthly rain markets
+    try {
+      const monthlyMarkets = await fetchMarkets(RAIN_SERIES.nycMonthly);
+      const processed = processMonthlyRainMarkets(monthlyMarkets);
+
+      if (processed && processed.topBrackets.length > 0) {
+        results['new-york'] = {
+          ...processed,
+          cityName: 'New York',
+          citySlug: 'new-york',
+          loading: false,
+          error: null,
+        };
+      }
+    } catch (err) {
+      console.log('Monthly rain markets not found:', err.message);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Fetch daily rain markets
+    try {
+      const dailyMarkets = await fetchMarkets(RAIN_SERIES.nycDaily);
+      const processed = processDailyRainMarkets(dailyMarkets);
+
+      if (processed && processed.topBrackets.length > 0) {
+        results['new-york-daily'] = {
+          ...processed,
+          cityName: 'NYC Daily',
+          citySlug: 'new-york-daily',
+          loading: false,
+          error: null,
+        };
+      }
+    } catch (err) {
+      console.log('Daily rain markets not found:', err.message);
+    }
+
+    setMarketsData(results);
+    setLoading(false);
+    setLastFetch(new Date());
+  }, []);
+
+  useEffect(() => {
+    fetchAllRainMarkets();
+  }, [fetchAllRainMarkets]);
+
+  // Refresh every 30 seconds
+  useEffect(() => {
+    const interval = setInterval(fetchAllRainMarkets, 30000);
+    return () => clearInterval(interval);
+  }, [fetchAllRainMarkets]);
+
+  // Convert to sorted array by volume
+  const sortedMarkets = Object.values(marketsData)
+    .filter(m => !m.error && m.topBrackets?.length > 0)
+    .sort((a, b) => (b.totalVolume || 0) - (a.totalVolume || 0))
+    .map(m => ({
+      slug: m.citySlug,
+      name: m.cityName,
+      topBrackets: m.topBrackets,
+      totalVolume: m.totalVolume,
+      closeTime: m.closeTime,
+    }));
+
+  return {
+    markets: sortedMarkets,
+    marketsData,
+    loading,
+    error,
+    lastFetch,
+    refetch: fetchAllRainMarkets,
+  };
+}
+
+export default useKalshiRainMarkets;

--- a/src/hooks/useKalshiSnowMarkets.js
+++ b/src/hooks/useKalshiSnowMarkets.js
@@ -1,0 +1,227 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Kalshi API - uses proxy to bypass CORS
+ */
+const KALSHI_PROXY = '/api/kalshi';
+const KALSHI_PATH = 'trade-api/v2';
+
+/**
+ * Map city slugs to Kalshi snow series tickers
+ * Monthly snow accumulation markets: KX{CITY}SNOWM
+ */
+export const SNOW_CITY_SERIES = {
+  'new-york': 'KXNYCSNOWM',
+  'chicago': 'KXCHISNOWM',
+  'salt-lake-city': 'KXSLCSNOWM',
+  'boston': 'KXBOSSNOWM',
+  'seattle': 'KXSEASNOWM',
+  'philadelphia': 'KXPHLSNOWM',
+  'washington-dc': 'KXDCSNOWM',
+  'detroit': 'KXDETSNOWM',
+  'dallas': 'KXDALSNOWM',
+  'miami': 'KXMIASNOWM',
+  'san-francisco': 'KXSFOSNOWM',
+  'los-angeles': 'KXLAXSNOWM',
+  'austin': 'KXAUSSNOWM',
+  'houston': 'KXHOUSNOWM',
+};
+
+/**
+ * City metadata for snow markets
+ */
+export const SNOW_CITIES = [
+  { slug: 'new-york', name: 'New York', id: 'NYC' },
+  { slug: 'chicago', name: 'Chicago', id: 'CHI' },
+  { slug: 'salt-lake-city', name: 'Salt Lake City', id: 'SLC' },
+  { slug: 'boston', name: 'Boston', id: 'BOS' },
+  { slug: 'seattle', name: 'Seattle', id: 'SEA' },
+  { slug: 'philadelphia', name: 'Philadelphia', id: 'PHL' },
+  { slug: 'washington-dc', name: 'Washington DC', id: 'DC' },
+  { slug: 'detroit', name: 'Detroit', id: 'DET' },
+  { slug: 'dallas', name: 'Dallas', id: 'DAL' },
+  { slug: 'miami', name: 'Miami', id: 'MIA' },
+  { slug: 'san-francisco', name: 'San Francisco', id: 'SFO' },
+  { slug: 'los-angeles', name: 'Los Angeles', id: 'LAX' },
+  { slug: 'austin', name: 'Austin', id: 'AUS' },
+  { slug: 'houston', name: 'Houston', id: 'HOU' },
+];
+
+/**
+ * Get current month's date suffix for Kalshi ticker (e.g., "25DEC" for Dec 2025)
+ */
+function getCurrentMonthSuffix() {
+  const now = new Date();
+  const year = now.getFullYear().toString().slice(-2);
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+  const month = months[now.getMonth()];
+  return `${year}${month}`;
+}
+
+/**
+ * Fetch markets for a snow series
+ */
+async function fetchSnowMarkets(seriesTicker) {
+  const url = `${KALSHI_PROXY}?path=${KALSHI_PATH}/markets&series_ticker=${seriesTicker}&limit=50`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.markets || [];
+}
+
+/**
+ * Process snow market data
+ * Snow markets have multiple brackets for different accumulation levels
+ */
+function processSnowMarkets(markets, cityName) {
+  if (!markets || markets.length === 0) return null;
+
+  const currentMonth = getCurrentMonthSuffix();
+
+  // Filter for current month's markets
+  const currentMarkets = markets.filter(m =>
+    m.ticker.includes(`-${currentMonth}`) && m.status === 'active'
+  );
+
+  if (currentMarkets.length === 0) {
+    // Fall back to any active markets
+    const activeMarkets = markets.filter(m => m.status === 'active');
+    if (activeMarkets.length === 0) return null;
+    return processMarketList(activeMarkets, cityName);
+  }
+
+  return processMarketList(currentMarkets, cityName);
+}
+
+/**
+ * Process a list of markets into displayable format
+ */
+function processMarketList(markets, cityName) {
+  // Sort by yes_bid price descending to get top brackets
+  const sorted = [...markets].sort((a, b) => (b.yes_bid || 0) - (a.yes_bid || 0));
+
+  // Calculate total volume
+  const totalVolume = markets.reduce((sum, m) => sum + (m.volume || 0), 0);
+
+  // Get close time from first market
+  const closeTime = sorted[0]?.close_time ? new Date(sorted[0].close_time) : null;
+
+  // Extract top 2 brackets
+  const topBrackets = sorted.slice(0, 2).map(m => {
+    // Parse the subtitle to get the threshold (e.g., "Above 10.0 inches")
+    let label = m.subtitle || m.yes_sub_title || 'Snow';
+    // Condense label
+    label = label.replace(/Above\s+/i, '≥').replace(/\s+inches?/i, '"');
+
+    return {
+      label,
+      yesPrice: m.yes_bid || 0,
+      ticker: m.ticker,
+    };
+  });
+
+  return {
+    topBrackets,
+    totalVolume,
+    closeTime,
+    title: `Snow in ${cityName} this month?`,
+  };
+}
+
+/**
+ * Hook to fetch all snow markets
+ */
+export function useKalshiSnowMarkets() {
+  const [marketsData, setMarketsData] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [lastFetch, setLastFetch] = useState(null);
+
+  const fetchAllSnowMarkets = useCallback(async () => {
+    const results = {};
+
+    for (const city of SNOW_CITIES) {
+      const seriesTicker = SNOW_CITY_SERIES[city.slug];
+      if (!seriesTicker) continue;
+
+      try {
+        const markets = await fetchSnowMarkets(seriesTicker);
+        const processed = processSnowMarkets(markets, city.name);
+
+        if (processed && processed.topBrackets.length > 0) {
+          results[city.slug] = {
+            ...processed,
+            cityName: city.name,
+            citySlug: city.slug,
+            loading: false,
+            error: null,
+          };
+        } else {
+          results[city.slug] = {
+            cityName: city.name,
+            citySlug: city.slug,
+            topBrackets: [],
+            totalVolume: 0,
+            closeTime: null,
+            loading: false,
+            error: 'No active markets',
+          };
+        }
+      } catch (err) {
+        results[city.slug] = {
+          cityName: city.name,
+          citySlug: city.slug,
+          topBrackets: [],
+          totalVolume: 0,
+          closeTime: null,
+          loading: false,
+          error: err.message,
+        };
+      }
+
+      // Small delay between requests to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    setMarketsData(results);
+    setLoading(false);
+    setLastFetch(new Date());
+  }, []);
+
+  useEffect(() => {
+    fetchAllSnowMarkets();
+  }, [fetchAllSnowMarkets]);
+
+  // Refresh every 30 seconds
+  useEffect(() => {
+    const interval = setInterval(fetchAllSnowMarkets, 30000);
+    return () => clearInterval(interval);
+  }, [fetchAllSnowMarkets]);
+
+  // Convert to sorted array by volume
+  const sortedMarkets = Object.values(marketsData)
+    .filter(m => !m.error && m.topBrackets?.length > 0)
+    .sort((a, b) => (b.totalVolume || 0) - (a.totalVolume || 0))
+    .map(m => ({
+      slug: m.citySlug,
+      name: m.cityName,
+      topBrackets: m.topBrackets,
+      totalVolume: m.totalVolume,
+      closeTime: m.closeTime,
+    }));
+
+  return {
+    markets: sortedMarkets,
+    marketsData,
+    loading,
+    error,
+    lastFetch,
+    refetch: fetchAllSnowMarkets,
+  };
+}
+
+export default useKalshiSnowMarkets;


### PR DESCRIPTION
## Summary
- Redesigns homepage to showcase all Kalshi weather prediction markets
- Adds Temperature, Rain, and Snow market sections with top 3 by volume displayed
- Creates "Show all" modal to view all markets in each category
- Fetches real data from Kalshi API for rain (NYC daily + monthly) and snow (14 cities)

## New Components
- `HomePageMarkets` - Main markets dashboard homepage
- `MarketCardGlass` - Glass-styled market card with probability bars
- `AllMarketsModal` - Popup showing all markets in a category

## New Hooks
- `useKalshiRainMarkets` - Fetches NYC rain markets (daily + monthly accumulation)
- `useKalshiSnowMarkets` - Fetches snow markets for 14 cities

## Test plan
- [ ] Verify homepage loads with temperature markets
- [ ] Verify rain markets section displays NYC data (or "No Active Markets")
- [ ] Verify snow markets section displays all 14 cities
- [ ] Test "Show all" modal opens and displays all markets
- [ ] Verify clicking a market card navigates to city dashboard
- [ ] Test mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)