### PR TITLE
Add multi-bracket price chart to market modal

### DIFF
--- a/src/components/weather/MarketBracketsModal.jsx
+++ b/src/components/weather/MarketBracketsModal.jsx
@@ -12,6 +12,8 @@ import {
 } from 'recharts';
 import { useKalshiCandlesticks, PERIODS } from '../../hooks/useKalshiCandlesticks';
 import { useKalshiOrderbook } from '../../hooks/useKalshiOrderbook';
+import { useKalshiMultiBracketHistory } from '../../hooks/useKalshiMultiBracketHistory';
+import MultiBracketChart from './MultiBracketChart';
 
 /**
  * MarketBracketsModal - Detailed view of Kalshi market brackets
@@ -26,6 +28,15 @@ export default function MarketBracketsModal({
   onClose,
 }) {
   const [expandedBracket, setExpandedBracket] = useState(null);
+  const [chartPeriod, setChartPeriod] = useState('1d');
+
+  // Fetch multi-bracket price history for the overview chart
+  const {
+    data: chartData,
+    legendData,
+    bracketColors,
+    loading: chartLoading,
+  } = useKalshiMultiBracketHistory(seriesTicker, brackets, chartPeriod, 4, true);
 
   // Format time remaining
   const formatTimeRemaining = () => {
@@ -135,8 +146,20 @@ export default function MarketBracketsModal({
             </div>
           </div>
 
+          {/* Multi-Bracket Price Chart */}
+          <div className="px-4 py-3 border-b border-white/10">
+            <MultiBracketChart
+              data={chartData}
+              legendData={legendData}
+              bracketColors={bracketColors}
+              period={chartPeriod}
+              onPeriodChange={setChartPeriod}
+              loading={chartLoading}
+            />
+          </div>
+
           {/* Brackets List */}
-          <div className="overflow-y-auto max-h-[55vh] glass-scroll">
+          <div className="overflow-y-auto max-h-[40vh] glass-scroll">
             {sortedBrackets.length === 0 ? (
               <div className="px-4 py-8 text-center text-white/40 text-sm">
                 No markets available for {dayLabel.toLowerCase()}

--- a/src/components/weather/MultiBracketChart.jsx
+++ b/src/components/weather/MultiBracketChart.jsx
@@ -1,0 +1,241 @@
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+} from 'recharts';
+
+/**
+ * Condense bracket label for display
+ * "38° to 39°" -> "38-39°F"
+ * "45° or above" -> "≥45°F"
+ * "30° or below" -> "≤30°F"
+ */
+function condenseLabel(label) {
+  if (!label) return '';
+
+  // Handle range: "38° to 39°" -> "38-39°F"
+  const rangeMatch = label.match(/(\d+)°?\s*to\s*(\d+)°?/i);
+  if (rangeMatch) {
+    return `${rangeMatch[1]}-${rangeMatch[2]}°F`;
+  }
+
+  // Handle "or above"
+  const aboveMatch = label.match(/(\d+)°?\s*(or above|and above|\+)/i);
+  if (aboveMatch) {
+    return `≥${aboveMatch[1]}°F`;
+  }
+
+  // Handle "or below"
+  const belowMatch = label.match(/(\d+)°?\s*(or below|and below)/i);
+  if (belowMatch) {
+    return `≤${belowMatch[1]}°F`;
+  }
+
+  return label;
+}
+
+/**
+ * MultiBracketChart - Shows price history for multiple brackets on one chart
+ * Similar to Polymarket's multi-outcome view
+ */
+export default function MultiBracketChart({
+  data,
+  legendData,
+  bracketColors,
+  period,
+  onPeriodChange,
+  loading,
+}) {
+  const periods = ['1h', '6h', '1d', '1w', 'all'];
+  const periodLabels = { '1h': '1H', '6h': '6H', '1d': '1D', '1w': '1W', 'all': 'ALL' };
+
+  // Calculate Y-axis domain
+  const { minPrice, maxPrice } = useMemo(() => {
+    if (!data || data.length === 0) return { minPrice: 0, maxPrice: 100 };
+
+    const allPrices = [];
+    legendData.forEach(({ label }) => {
+      data.forEach(d => {
+        if (d[label] != null) allPrices.push(d[label]);
+      });
+    });
+
+    if (allPrices.length === 0) return { minPrice: 0, maxPrice: 100 };
+
+    const min = Math.min(...allPrices);
+    const max = Math.max(...allPrices);
+    const padding = Math.max(5, (max - min) * 0.1);
+
+    return {
+      minPrice: Math.max(0, Math.floor(min - padding)),
+      maxPrice: Math.min(100, Math.ceil(max + padding)),
+    };
+  }, [data, legendData]);
+
+  // Custom tooltip
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (!active || !payload || payload.length === 0) return null;
+
+    const timeData = payload[0]?.payload;
+    const timeLabel = timeData?.timeLabel || '--';
+
+    return (
+      <div className="bg-black/90 backdrop-blur-sm px-3 py-2 rounded-lg text-xs border border-white/10 shadow-xl">
+        <div className="text-white/60 mb-1.5 font-medium">{timeLabel}</div>
+        <div className="space-y-1">
+          {payload.map((entry, idx) => (
+            <div key={idx} className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-1.5">
+                <div
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="text-white/70">{condenseLabel(entry.dataKey)}</span>
+              </div>
+              <span className="font-medium text-white">{entry.value}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  // Custom legend
+  const renderLegend = () => (
+    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mb-2">
+      {legendData.map(({ label, color, currentPrice }) => (
+        <div key={label} className="flex items-center gap-1.5 text-xs">
+          <div
+            className="w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-white/70">{condenseLabel(label)}</span>
+          <span className="font-semibold text-white">{currentPrice}%</span>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="bg-white/5 rounded-xl p-3">
+      {/* Legend */}
+      {renderLegend()}
+
+      {/* Chart */}
+      <div className="h-[180px]">
+        {loading ? (
+          <div className="h-full flex items-center justify-center">
+            <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
+          </div>
+        ) : data.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-white/40 text-sm">
+            No price history available
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 5, left: -15, bottom: 0 }}>
+              <XAxis
+                dataKey="timestamp"
+                type="number"
+                domain={['dataMin', 'dataMax']}
+                tick={{ fontSize: 10, fill: 'rgba(255,255,255,0.4)' }}
+                tickLine={false}
+                axisLine={{ stroke: 'rgba(255,255,255,0.1)' }}
+                tickFormatter={(ts) => {
+                  const date = new Date(ts * 1000);
+                  if (period === '1h' || period === '6h') {
+                    return date.toLocaleTimeString('en-US', {
+                      hour: 'numeric',
+                      minute: '2-digit',
+                      hour12: true,
+                    });
+                  }
+                  if (period === '1d') {
+                    return date.toLocaleTimeString('en-US', {
+                      hour: 'numeric',
+                      hour12: true,
+                    });
+                  }
+                  return date.toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  });
+                }}
+                interval="preserveStartEnd"
+                minTickGap={40}
+              />
+              <YAxis
+                domain={[minPrice, maxPrice]}
+                tick={{ fontSize: 10, fill: 'rgba(255,255,255,0.4)' }}
+                tickLine={false}
+                axisLine={false}
+                width={35}
+                tickFormatter={(v) => `${v}%`}
+              />
+              <Tooltip content={<CustomTooltip />} />
+
+              {/* Render a line for each bracket */}
+              {legendData.map(({ label, color }) => (
+                <Line
+                  key={label}
+                  type="monotone"
+                  dataKey={label}
+                  stroke={color}
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls
+                  activeDot={{
+                    r: 4,
+                    fill: color,
+                    stroke: 'rgba(255,255,255,0.4)',
+                    strokeWidth: 2,
+                  }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Period Selector */}
+      <div className="flex items-center justify-center mt-2">
+        <div className="flex bg-white/10 rounded-lg p-0.5">
+          {periods.map((p) => (
+            <button
+              key={p}
+              onClick={() => onPeriodChange(p)}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-all ${
+                period === p
+                  ? 'bg-white/20 text-white'
+                  : 'text-white/50 hover:text-white/70'
+              }`}
+            >
+              {periodLabels[p]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+MultiBracketChart.propTypes = {
+  data: PropTypes.array.isRequired,
+  legendData: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      color: PropTypes.string.isRequired,
+      currentPrice: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  bracketColors: PropTypes.object.isRequired,
+  period: PropTypes.string.isRequired,
+  onPeriodChange: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+};

--- a/src/hooks/useKalshiMultiBracketHistory.js
+++ b/src/hooks/useKalshiMultiBracketHistory.js
@@ -1,0 +1,233 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Kalshi API proxy endpoint
+ */
+const KALSHI_PROXY = '/api/kalshi';
+const KALSHI_PATH = 'trade-api/v2';
+
+/**
+ * Period configuration for candlestick data
+ * Kalshi supports: 1 (1 min), 60 (1 hour), 1440 (1 day)
+ */
+export const MULTI_PERIODS = {
+  '1h': { interval: 1, hours: 1 },      // 1-minute candles for 1 hour
+  '6h': { interval: 60, hours: 6 },     // 1-hour candles for 6 hours
+  '1d': { interval: 60, hours: 24 },    // 1-hour candles for 1 day
+  '1w': { interval: 1440, hours: 168 }, // 1-day candles for 1 week
+  'all': { interval: 1440, hours: 720 },// 1-day candles for 30 days
+};
+
+/**
+ * Fetch candlesticks for a single ticker
+ */
+async function fetchCandlesticks(seriesTicker, ticker, periodInterval, hoursBack) {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - hoursBack * 60 * 60 * 1000);
+
+  const params = new URLSearchParams({
+    path: `${KALSHI_PATH}/series/${seriesTicker}/markets/${ticker}/candlesticks`,
+    start_ts: Math.floor(startTime.getTime() / 1000).toString(),
+    end_ts: Math.floor(now.getTime() / 1000).toString(),
+    period_interval: periodInterval.toString(),
+  });
+
+  const url = `${KALSHI_PROXY}?${params.toString()}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.candlesticks || [];
+}
+
+/**
+ * Transform raw candlestick data to chart format
+ */
+function transformCandles(rawCandles, bracketLabel) {
+  return rawCandles
+    .map(c => {
+      const ts = c.end_period_ts || c.ts || 0;
+
+      // Extract price from yes_bid or price object
+      let yesPrice = 0;
+      if (c.yes_bid && typeof c.yes_bid === 'object') {
+        yesPrice = c.yes_bid.close || c.yes_bid.mean || c.yes_bid.open || 0;
+      }
+      if (yesPrice === 0 && c.price && typeof c.price === 'object') {
+        yesPrice = c.price.close || c.price.mean || c.price.open || 0;
+      }
+
+      return {
+        timestamp: ts,
+        price: yesPrice,
+        label: bracketLabel,
+      };
+    })
+    .filter(c => c.timestamp > 0 && c.price > 0);
+}
+
+/**
+ * Hook to fetch Kalshi candlestick data for multiple brackets simultaneously
+ * Returns merged data suitable for a multi-line chart
+ *
+ * @param {string} seriesTicker - Series ticker (e.g., "KXHIGHNY")
+ * @param {Array} brackets - Array of bracket objects with {ticker, label, yesPrice}
+ * @param {string} period - Period key: '1h', '6h', '1d', '1w', 'all'
+ * @param {number} maxBrackets - Maximum brackets to fetch (default: 4)
+ * @param {boolean} enabled - Whether to fetch data
+ */
+export function useKalshiMultiBracketHistory(
+  seriesTicker,
+  brackets = [],
+  period = '1d',
+  maxBrackets = 4,
+  enabled = true
+) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [bracketColors, setBracketColors] = useState({});
+
+  // Color palette for chart lines (monochromatic blues + accent)
+  const colors = ['#60A5FA', '#3B82F6', '#F59E0B', '#8B5CF6'];
+
+  const fetchData = useCallback(async () => {
+    if (!seriesTicker || !brackets.length || !enabled) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const periodConfig = MULTI_PERIODS[period] || MULTI_PERIODS['1d'];
+
+    // Get top N brackets by probability
+    const topBrackets = [...brackets]
+      .sort((a, b) => b.yesPrice - a.yesPrice)
+      .slice(0, maxBrackets);
+
+    // Assign colors to brackets
+    const colorMap = {};
+    topBrackets.forEach((b, idx) => {
+      colorMap[b.label] = colors[idx % colors.length];
+    });
+    setBracketColors(colorMap);
+
+    try {
+      // Fetch candlesticks sequentially with delay to avoid rate limiting
+      const results = [];
+      for (let i = 0; i < topBrackets.length; i++) {
+        const bracket = topBrackets[i];
+
+        // Add delay between requests (except first one)
+        if (i > 0) {
+          await new Promise(resolve => setTimeout(resolve, 200));
+        }
+
+        try {
+          const candles = await fetchCandlesticks(
+            seriesTicker,
+            bracket.ticker,
+            periodConfig.interval,
+            periodConfig.hours
+          );
+          results.push({
+            bracket,
+            candles: transformCandles(candles, bracket.label),
+          });
+        } catch (err) {
+          console.warn(`[MultiBracket] Failed to fetch ${bracket.label}:`, err);
+          results.push({ bracket, candles: [] });
+        }
+      }
+
+      // Merge all candlestick data by timestamp
+      const timestampMap = new Map();
+
+      results.forEach(({ bracket, candles }) => {
+        candles.forEach(c => {
+          if (!timestampMap.has(c.timestamp)) {
+            timestampMap.set(c.timestamp, { timestamp: c.timestamp });
+          }
+          const entry = timestampMap.get(c.timestamp);
+          entry[bracket.label] = c.price;
+        });
+      });
+
+      // Convert to array and sort by timestamp
+      const mergedData = Array.from(timestampMap.values())
+        .sort((a, b) => a.timestamp - b.timestamp);
+
+      // Add time labels
+      const formattedData = mergedData.map(d => ({
+        ...d,
+        time: new Date(d.timestamp * 1000),
+        timeLabel: formatTimeLabel(d.timestamp, period),
+      }));
+
+      setData(formattedData);
+    } catch (err) {
+      console.error('[MultiBracket] Error:', err);
+      setError(err.message);
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [seriesTicker, brackets, period, maxBrackets, enabled]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Get bracket info for legend
+  const legendData = brackets
+    .sort((a, b) => b.yesPrice - a.yesPrice)
+    .slice(0, maxBrackets)
+    .map(b => ({
+      label: b.label,
+      color: bracketColors[b.label] || '#fff',
+      currentPrice: b.yesPrice,
+    }));
+
+  return {
+    data,
+    legendData,
+    bracketColors,
+    loading,
+    error,
+    refetch: fetchData,
+  };
+}
+
+/**
+ * Format timestamp for display based on period
+ */
+function formatTimeLabel(timestamp, period) {
+  const date = new Date(timestamp * 1000);
+
+  if (period === '1h' || period === '6h') {
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }
+
+  if (period === '1d') {
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      hour12: true,
+    });
+  }
+
+  // For 1w and all, show date
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default useKalshiMultiBracketHistory;


### PR DESCRIPTION
## Summary
- Add Polymarket-style multi-line price chart showing top 4 brackets at the top of the market modal
- Create `useKalshiMultiBracketHistory` hook for fetching candlestick data from Kalshi API
- Create `MultiBracketChart` component with Recharts visualization
- Support 5 time periods: 1H, 6H, 1D (default), 1W, ALL

## Test plan
- [ ] Open market modal from city page widget
- [ ] Verify chart shows 4 colored lines for top brackets
- [ ] Click period buttons (1H, 6H, 1D, 1W, ALL) and verify chart updates
- [ ] Expand individual bracket rows to confirm existing functionality still works
- [ ] Verify no 429 rate limit errors in console (sequential fetch with delays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)