### PR TITLE
Add quick-add data chips for market brackets

### DIFF
--- a/src/components/dashboard/CityDashboardNew.jsx
+++ b/src/components/dashboard/CityDashboardNew.jsx
@@ -6,6 +6,7 @@ import { useNWSWeather } from '../../hooks/useNWSWeather';
 import { useNWSHourlyForecast } from '../../hooks/useNWSHourlyForecast';
 import { useNWSObservationHistory } from '../../hooks/useNWSObservationHistory';
 import { useNotesSidebar } from '../../context/NotesSidebarContext';
+import { DataChipProvider } from '../../context/DataChipContext';
 import { DashboardWeatherBackground } from '../weather/DynamicWeatherBackground';
 
 // Weather Components
@@ -307,5 +308,9 @@ export default function CityDashboardNew() {
     );
   }
 
-  return <CityDashboardContent city={city} citySlug={citySlug} />;
+  return (
+    <DataChipProvider>
+      <CityDashboardContent city={city} citySlug={citySlug} />
+    </DataChipProvider>
+  );
 }

--- a/src/components/layout/NotesSidebar.jsx
+++ b/src/components/layout/NotesSidebar.jsx
@@ -1,6 +1,5 @@
 import { FileText, ChevronLeft, Check, Loader2, FilePlus, Trash2, ChevronDown, Clock, X, ExternalLink } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
-import { DataChipProvider } from '../../context/DataChipContext';
 import { NotepadProvider, useNotepad } from '../../context/NotepadContext';
 import { useNotesSidebar } from '../../context/NotesSidebarContext';
 import NotepadEditor from '../notepad/NotepadEditor';
@@ -416,9 +415,8 @@ export default function NotesSidebar({ storageKey, cityName }) {
           ${isCollapsed ? 'translate-x-[calc(100%+12px)]' : 'translate-x-0'}
         `}
       >
-        <DataChipProvider>
-          <NotepadProvider storageKey={storageKey}>
-            <div className="h-full flex flex-col">
+        <NotepadProvider storageKey={storageKey}>
+          <div className="h-full flex flex-col">
               {/* Header */}
               <div className="p-3">
                 <div className="flex items-center justify-between">
@@ -482,9 +480,8 @@ export default function NotesSidebar({ storageKey, cityName }) {
                   <ResearchLog />
                 </div>
               </div>
-            </div>
-          </NotepadProvider>
-        </DataChipProvider>
+          </div>
+        </NotepadProvider>
       </aside>
     </>
   );

--- a/src/components/notepad/DataChipComponent.jsx
+++ b/src/components/notepad/DataChipComponent.jsx
@@ -12,7 +12,7 @@ const TYPE_COLORS = {
 };
 
 export default function DataChipComponent({ node }) {
-  const { value, label, source, timestamp, type } = node.attrs;
+  const { value, secondary, label, source, timestamp, type } = node.attrs;
   const colorClasses = TYPE_COLORS[type] || TYPE_COLORS.default;
   const chipType = type || 'default';
 
@@ -21,6 +21,7 @@ export default function DataChipComponent({ node }) {
       <span className={`data-chip ${colorClasses}`} data-chip-type={chipType}>
         {label && <span className="data-chip-label">{label}</span>}
         <span className="data-chip-value">{value}</span>
+        {secondary && <span className="data-chip-secondary">{secondary}</span>}
         <span className="data-chip-meta">{source} • {timestamp}</span>
       </span>
     </NodeViewWrapper>

--- a/src/components/notepad/extensions/DataChipNode.js
+++ b/src/components/notepad/extensions/DataChipNode.js
@@ -11,6 +11,7 @@ export const DataChipNode = Node.create({
   addAttributes() {
     return {
       value: { default: '' },
+      secondary: { default: '' },
       label: { default: '' },
       source: { default: '' },
       timestamp: { default: '' },
@@ -24,6 +25,7 @@ export const DataChipNode = Node.create({
         tag: 'data-chip',
         getAttrs: (dom) => ({
           value: dom.getAttribute('data-value'),
+          secondary: dom.getAttribute('data-secondary'),
           label: dom.getAttribute('data-label'),
           source: dom.getAttribute('data-source'),
           timestamp: dom.getAttribute('data-timestamp'),
@@ -38,6 +40,7 @@ export const DataChipNode = Node.create({
       'data-chip',
       mergeAttributes(HTMLAttributes, {
         'data-value': HTMLAttributes.value,
+        'data-secondary': HTMLAttributes.secondary,
         'data-label': HTMLAttributes.label,
         'data-source': HTMLAttributes.source,
         'data-timestamp': HTMLAttributes.timestamp,

--- a/src/styles/notepad.css
+++ b/src/styles/notepad.css
@@ -236,6 +236,12 @@
   font-weight: 600;
 }
 
+.data-chip-secondary {
+  font-weight: 400;
+  opacity: 0.7;
+  margin-left: 0.25rem;
+}
+
 .data-chip-meta {
   opacity: 0.7;
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Add quick-add button (orange +) to market bracket rows in both inline widget and modal
- Click to insert market odds as data chip into research notes
- Chip format: **33-34°F** (bold) **50%** (lighter) with source and timestamp
- Add `secondary` field to data chip system for bold/light styling

## Test plan
- [ ] Hover over bracket row in inline widget - orange + button appears
- [ ] Click + button - chip inserted into notes with bracket and percentage
- [ ] Open market modal, hover over bracket row - + button appears
- [ ] Click + button in modal - chip inserted into notes
- [ ] Verify chip shows bracket bold, percentage lighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)