### PR TITLE
Add GOES satellite imagery to weather map

### DIFF
--- a/src/components/weather/MapWidgetPopup.jsx
+++ b/src/components/weather/MapWidgetPopup.jsx
@@ -240,12 +240,12 @@ export default function MapWidgetPopup({
     return () => clearInterval(interval);
   }, [isOpen, activeLayer, satelliteReady]);
 
-  // Reset loading state when settings change
+  // Reset loading state when city or settings change
   useEffect(() => {
     loadingRef.current = false;
     framesRef.current = [];
     frameIndexRef.current = 0;
-  }, [satelliteBand, satelliteSector]);
+  }, [lat, lon, satelliteBand, satelliteSector]);
 
   // Initialize Leaflet map
   useEffect(() => {

--- a/src/components/weather/WeatherMap.jsx
+++ b/src/components/weather/WeatherMap.jsx
@@ -269,12 +269,12 @@ export default function WeatherMap({
     return () => clearInterval(interval);
   }, [activeTab, satelliteReady]);
 
-  // Reset loading state when settings change
+  // Reset loading state when city or settings change
   useEffect(() => {
     loadingRef.current = false;
     framesRef.current = [];
     frameIndexRef.current = 0;
-  }, [satelliteBand, satelliteSector]);
+  }, [lat, lon, satelliteBand, satelliteSector]);
 
   // Update map center when lat/lon changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
Add GOES satellite imagery to the weather map widget with animated loops.

### Features
- **Satellite tab** on main weather widget (default view)
- **GOES-18** for Pacific coast (Seattle, LA, SF)
- **GOES-19** for all other regions (replaced GOES-16)
- **Local sectors**: pnw, psw, nr, ne, umv, se, sp
- **Regional views**: Pacific (tpw), East US (eus)
- **Band options**: AirMass, GeoColor, Sandwich
- **Animated loop**: 3-4 hour history, auto-playing

### Optimizations
- Fast loading: show first valid frame immediately
- Background preloading for animation frames
- Ref-based animation (no re-renders during playback)
- Smooth city switching (old image stays until new loads)

### Cities Supported
| City | Satellite | Local Sector |
|------|-----------|--------------|
| Seattle | GOES-18 | pnw |
| San Francisco | GOES-18 | psw |
| Los Angeles | GOES-18 | psw |
| Denver | GOES-19 | nr |
| Salt Lake City | GOES-19 | nr |
| New York | GOES-19 | ne |
| Boston | GOES-19 | ne |
| Philadelphia | GOES-19 | ne |
| Chicago | GOES-19 | umv |
| Detroit | GOES-19 | ne |
| Washington DC | GOES-19 | ne |
| Miami | GOES-19 | se |
| Houston | GOES-19 | sp |
| Austin | GOES-19 | sp |
| Dallas | GOES-19 | sp |

## Test plan
- [ ] Verify satellite loads for all 15 cities
- [ ] Test city switching (no flicker or loading delay)
- [ ] Test band/sector selectors
- [ ] Verify animation loops smoothly
- [ ] Test popup modal satellite view

🤖 Generated with [Claude Code](https://claude.com/claude-code)