### PR TITLE
Add weather news to AlertsWidget when no NWS alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# NewsData.io API key for weather news
+# Get your free API key at https://newsdata.io/
+VITE_NEWSDATA_API_KEY=your_api_key_here

--- a/src/components/weather/AlertsNewsModal.jsx
+++ b/src/components/weather/AlertsNewsModal.jsx
@@ -1,0 +1,202 @@
+import PropTypes from 'prop-types';
+import { X, Clock, MapPin, ExternalLink, Newspaper, AlertTriangle } from 'lucide-react';
+import { getAlertColor, getAlertIcon } from '../../hooks/useNWSAlerts';
+import { formatNewsTime } from '../../hooks/useWeatherNews';
+
+/**
+ * AlertsNewsModal - Full-screen modal showing alerts and weather news
+ */
+export default function AlertsNewsModal({ alerts, news, cityName, onClose }) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="glass max-w-2xl w-full max-h-[85vh] overflow-hidden rounded-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-white/10 flex items-center justify-between flex-shrink-0">
+          <div>
+            <h2 className="text-lg font-bold text-white">Alerts & Weather News</h2>
+            <p className="text-xs text-white/50">{cityName}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-white/10 rounded-lg transition-colors"
+          >
+            <X className="w-5 h-5 text-white/60" />
+          </button>
+        </div>
+
+        {/* Scrollable Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-6">
+          {/* Active Alerts Section */}
+          {alerts.length > 0 && (
+            <section>
+              <div className="flex items-center gap-2 mb-3">
+                <AlertTriangle className="w-4 h-4 text-orange-400" />
+                <h3 className="text-sm font-semibold text-white uppercase tracking-wide">
+                  Active Alerts ({alerts.length})
+                </h3>
+              </div>
+
+              <div className="space-y-3">
+                {alerts.map((alert) => {
+                  const colors = getAlertColor(alert.severity);
+                  const icon = getAlertIcon(alert.event);
+
+                  return (
+                    <div
+                      key={alert.id}
+                      className={`p-3 rounded-xl ${colors.bg} ${colors.border} border`}
+                    >
+                      {/* Alert Header */}
+                      <div className="flex items-start gap-3 mb-2">
+                        <span className="text-2xl">{icon}</span>
+                        <div className="flex-1">
+                          <h4 className={`text-sm font-bold ${colors.text}`}>{alert.event}</h4>
+                          <p className="text-[10px] text-white/50">
+                            {alert.severity} • {alert.urgency}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Headline */}
+                      {alert.headline && (
+                        <p className="text-xs text-white/80 mb-2">{alert.headline}</p>
+                      )}
+
+                      {/* Time and Area */}
+                      <div className="flex flex-wrap gap-3 text-[10px] text-white/50 mb-2">
+                        {alert.expires && (
+                          <div className="flex items-center gap-1">
+                            <Clock className="w-3 h-3" />
+                            <span>Expires: {alert.expires.toLocaleString()}</span>
+                          </div>
+                        )}
+                        {alert.areaDesc && (
+                          <div className="flex items-center gap-1">
+                            <MapPin className="w-3 h-3" />
+                            <span className="line-clamp-1">{alert.areaDesc}</span>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Description (collapsible could be added later) */}
+                      {alert.description && (
+                        <details className="text-xs text-white/70">
+                          <summary className="cursor-pointer text-white/50 hover:text-white/70 mb-1">
+                            View full details
+                          </summary>
+                          <p className="whitespace-pre-wrap leading-relaxed mt-2 pl-2 border-l-2 border-white/10">
+                            {alert.description}
+                          </p>
+                        </details>
+                      )}
+
+                      {/* Instructions */}
+                      {alert.instruction && (
+                        <div className="mt-3 p-2 rounded-lg bg-white/5">
+                          <p className="text-[10px] font-semibold text-white/60 uppercase mb-1">
+                            What to do
+                          </p>
+                          <p className="text-xs text-white/80 whitespace-pre-wrap">
+                            {alert.instruction}
+                          </p>
+                        </div>
+                      )}
+
+                      {/* Source */}
+                      {alert.senderName && (
+                        <p className="text-[9px] text-white/30 mt-2">
+                          Source: {alert.senderName}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Weather News Section */}
+          <section>
+            <div className="flex items-center gap-2 mb-3">
+              <Newspaper className="w-4 h-4 text-blue-400" />
+              <h3 className="text-sm font-semibold text-white uppercase tracking-wide">
+                Weather News
+              </h3>
+            </div>
+
+            {news.length === 0 ? (
+              <div className="text-center py-6 text-white/40 text-xs">
+                No weather news available
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {news.map((item) => (
+                  <a
+                    key={item.id}
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block p-3 rounded-xl bg-white/5 hover:bg-white/10 transition-colors group"
+                  >
+                    <div className="flex items-start gap-3">
+                      {/* Thumbnail */}
+                      {item.imageUrl && (
+                        <div className="w-16 h-16 rounded-lg overflow-hidden flex-shrink-0 bg-white/10">
+                          <img
+                            src={item.imageUrl}
+                            alt=""
+                            className="w-full h-full object-cover"
+                            onError={(e) => e.target.style.display = 'none'}
+                          />
+                        </div>
+                      )}
+
+                      <div className="flex-1 min-w-0">
+                        <h4 className="text-sm font-medium text-white group-hover:text-blue-300 transition-colors line-clamp-2">
+                          {item.title}
+                        </h4>
+
+                        {item.description && (
+                          <p className="text-xs text-white/50 line-clamp-2 mt-1">
+                            {item.description}
+                          </p>
+                        )}
+
+                        <div className="flex items-center gap-2 mt-2 text-[10px] text-white/40">
+                          {item.source && <span>{item.source}</span>}
+                          {item.source && item.publishedAt && <span>•</span>}
+                          {item.publishedAt && <span>{formatNewsTime(item.publishedAt)}</span>}
+                          <ExternalLink className="w-3 h-3 ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="p-3 border-t border-white/10 flex-shrink-0">
+          <p className="text-[10px] text-white/30 text-center">
+            Alerts: National Weather Service • News: NewsData.io
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+AlertsNewsModal.propTypes = {
+  alerts: PropTypes.array.isRequired,
+  news: PropTypes.array.isRequired,
+  cityName: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/weather/AlertsWidget.jsx
+++ b/src/components/weather/AlertsWidget.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { AlertTriangle, ChevronRight, X, Clock, MapPin } from 'lucide-react';
+import { AlertTriangle, ChevronRight, Newspaper } from 'lucide-react';
 import { useNWSAlerts, getAlertColor, getAlertIcon } from '../../hooks/useNWSAlerts';
+import { useWeatherNews, formatNewsTime } from '../../hooks/useWeatherNews';
 import GlassWidget from './GlassWidget';
+import AlertsNewsModal from './AlertsNewsModal';
 
 /**
  * Format relative time
@@ -27,116 +29,15 @@ const formatTimeAgo = (date) => {
   }
 };
 
-/**
- * Alert Detail Modal
- */
-function AlertDetailModal({ alert, onClose }) {
-  if (!alert) return null;
-
-  const colors = getAlertColor(alert.severity);
-  const icon = getAlertIcon(alert.event);
-
-  return (
-    <div
-      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="glass max-w-lg w-full max-h-[80vh] overflow-y-auto rounded-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className={`p-4 border-b border-white/10 ${colors.bg}`}>
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-3">
-              <span className="text-2xl">{icon}</span>
-              <div>
-                <h2 className={`text-lg font-bold ${colors.text}`}>{alert.event}</h2>
-                <p className="text-xs text-white/60">{alert.severity} • {alert.urgency}</p>
-              </div>
-            </div>
-            <button
-              onClick={onClose}
-              className="p-2 hover:bg-white/10 rounded-lg transition-colors"
-            >
-              <X className="w-5 h-5 text-white/60" />
-            </button>
-          </div>
-        </div>
-
-        {/* Content */}
-        <div className="p-4 space-y-4">
-          {/* Headline */}
-          {alert.headline && (
-            <div>
-              <h3 className="text-sm font-semibold text-white mb-1">Summary</h3>
-              <p className="text-sm text-white/80">{alert.headline}</p>
-            </div>
-          )}
-
-          {/* Time info */}
-          <div className="flex flex-wrap gap-4 text-xs text-white/60">
-            {alert.onset && (
-              <div className="flex items-center gap-1">
-                <Clock className="w-3 h-3" />
-                <span>Started: {alert.onset.toLocaleString()}</span>
-              </div>
-            )}
-            {alert.expires && (
-              <div className="flex items-center gap-1">
-                <Clock className="w-3 h-3" />
-                <span>Expires: {alert.expires.toLocaleString()}</span>
-              </div>
-            )}
-          </div>
-
-          {/* Area */}
-          {alert.areaDesc && (
-            <div className="flex items-start gap-2 text-xs text-white/60">
-              <MapPin className="w-3 h-3 mt-0.5 flex-shrink-0" />
-              <span>{alert.areaDesc}</span>
-            </div>
-          )}
-
-          {/* Description */}
-          {alert.description && (
-            <div>
-              <h3 className="text-sm font-semibold text-white mb-1">Details</h3>
-              <p className="text-xs text-white/70 whitespace-pre-wrap leading-relaxed">
-                {alert.description}
-              </p>
-            </div>
-          )}
-
-          {/* Instructions */}
-          {alert.instruction && (
-            <div className={`p-3 rounded-lg ${colors.bg} ${colors.border} border`}>
-              <h3 className={`text-sm font-semibold ${colors.text} mb-1`}>What to do</h3>
-              <p className="text-xs text-white/80 whitespace-pre-wrap">
-                {alert.instruction}
-              </p>
-            </div>
-          )}
-
-          {/* Source */}
-          {alert.senderName && (
-            <p className="text-[10px] text-white/40 pt-2 border-t border-white/10">
-              Source: {alert.senderName}
-            </p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 /**
- * AlertsWidget - Shows NWS weather alerts
- * If no alerts, shows a "No active alerts" message
+ * AlertsWidget - Shows NWS weather alerts and weather news
+ * If no alerts, shows weather news instead
  */
 export default function AlertsWidget({ lat, lon, cityName }) {
   const { alerts, loading, error } = useNWSAlerts(lat, lon);
-  const [selectedAlert, setSelectedAlert] = useState(null);
+  const { news, loading: newsLoading } = useWeatherNews(cityName, alerts.length === 0 && !loading);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   if (loading) {
     return (
@@ -158,36 +59,103 @@ export default function AlertsWidget({ lat, lon, cityName }) {
     );
   }
 
-  // No alerts
+  // No alerts - show news instead
   if (alerts.length === 0) {
     return (
-      <GlassWidget title="ALERTS" icon={AlertTriangle} size="medium">
-        <div className="flex-1 flex flex-col items-center justify-center text-center px-4 py-2">
-          <div className="w-10 h-10 rounded-full bg-emerald-500/20 flex items-center justify-center mb-2">
-            <span className="text-xl">✓</span>
+      <>
+        <GlassWidget
+          title="ALERTS & NEWS"
+          icon={AlertTriangle}
+          size="large"
+          className="cursor-pointer"
+          onClick={() => setIsModalOpen(true)}
+        >
+          {/* No alerts badge */}
+          <div className="flex items-center gap-2 mb-2 pb-2 border-b border-white/10">
+            <div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center">
+              <span className="text-xs">✓</span>
+            </div>
+            <span className="text-[10px] text-emerald-400 font-medium">No Active Alerts</span>
           </div>
-          <p className="text-xs font-medium text-white/80">No Active Alerts</p>
-          <p className="text-[10px] text-white/40 mt-0.5">
-            {cityName || 'This area'} has no weather alerts
-          </p>
-        </div>
-      </GlassWidget>
+
+          {/* Weather News */}
+          {newsLoading ? (
+            <div className="flex-1 flex items-center justify-center">
+              <div className="w-5 h-5 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
+            </div>
+          ) : news.length > 0 ? (
+            <div className="flex-1 overflow-y-auto space-y-2">
+              <div className="flex items-center gap-1 text-[10px] text-white/40 mb-1">
+                <Newspaper className="w-3 h-3" />
+                <span>Weather News</span>
+              </div>
+              {news.slice(0, 3).map((item) => (
+                <div
+                  key={item.id}
+                  className="p-2 rounded-lg bg-white/5 hover:bg-white/10 transition-colors"
+                >
+                  <p className="text-xs text-white/80 line-clamp-2">{item.title}</p>
+                  <div className="flex items-center gap-2 mt-1 text-[9px] text-white/40">
+                    {item.source && <span>{item.source}</span>}
+                    {item.publishedAt && <span>• {formatNewsTime(item.publishedAt)}</span>}
+                  </div>
+                </div>
+              ))}
+              {news.length > 3 && (
+                <p className="text-[9px] text-white/40 text-center">
+                  +{news.length - 3} more articles
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center text-center px-4">
+              <p className="text-xs text-white/60">No weather news available</p>
+              <p className="text-[10px] text-white/40 mt-0.5">
+                {cityName || 'This area'} is all clear
+              </p>
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="pt-2 border-t border-white/10 mt-2 flex items-center justify-between">
+            <p className="text-[10px] text-white/40">
+              Tap for details
+            </p>
+            <ChevronRight className="w-3 h-3 text-white/30" />
+          </div>
+        </GlassWidget>
+
+        {/* Modal */}
+        {isModalOpen && (
+          <AlertsNewsModal
+            alerts={alerts}
+            news={news}
+            cityName={cityName}
+            onClose={() => setIsModalOpen(false)}
+          />
+        )}
+      </>
     );
   }
 
   return (
     <>
-      <GlassWidget title="ALERTS" icon={AlertTriangle} size="large">
+      <GlassWidget
+        title="ALERTS"
+        icon={AlertTriangle}
+        size="large"
+        className="cursor-pointer"
+        onClick={() => setIsModalOpen(true)}
+      >
         <div className="flex-1 overflow-y-auto space-y-2">
           {alerts.slice(0, 3).map((alert) => {
             const colors = getAlertColor(alert.severity);
             const icon = getAlertIcon(alert.event);
 
             return (
-              <button
+              <div
                 key={alert.id}
-                onClick={() => setSelectedAlert(alert)}
-                className={`w-full text-left p-2.5 rounded-lg ${colors.bg} ${colors.border} border transition-all hover:scale-[1.02]`}
+                className={`w-full text-left p-2.5 rounded-lg ${colors.bg} ${colors.border} border transition-all hover:bg-white/10`}
               >
                 <div className="flex items-start gap-2">
                   <span className="text-lg flex-shrink-0">{icon}</span>
@@ -196,7 +164,6 @@ export default function AlertsWidget({ lat, lon, cityName }) {
                       <span className={`text-xs font-bold ${colors.text} truncate`}>
                         {alert.event}
                       </span>
-                      <ChevronRight className="w-3 h-3 text-white/40 flex-shrink-0" />
                     </div>
                     <p className="text-[10px] text-white/60 line-clamp-2 mt-0.5">
                       {alert.headline || alert.description?.slice(0, 100)}
@@ -208,7 +175,7 @@ export default function AlertsWidget({ lat, lon, cityName }) {
                     )}
                   </div>
                 </div>
-              </button>
+              </div>
             );
           })}
 
@@ -220,18 +187,21 @@ export default function AlertsWidget({ lat, lon, cityName }) {
         </div>
 
         {/* Footer */}
-        <div className="pt-2 border-t border-white/10 mt-2">
+        <div className="pt-2 border-t border-white/10 mt-2 flex items-center justify-between">
           <p className="text-[10px] text-white/40">
-            Source: National Weather Service
+            Source: NWS
           </p>
+          <ChevronRight className="w-3 h-3 text-white/30" />
         </div>
       </GlassWidget>
 
       {/* Detail Modal */}
-      {selectedAlert && (
-        <AlertDetailModal
-          alert={selectedAlert}
-          onClose={() => setSelectedAlert(null)}
+      {isModalOpen && (
+        <AlertsNewsModal
+          alerts={alerts}
+          news={news}
+          cityName={cityName}
+          onClose={() => setIsModalOpen(false)}
         />
       )}
     </>

--- a/src/hooks/useWeatherNews.js
+++ b/src/hooks/useWeatherNews.js
@@ -1,0 +1,134 @@
+import { useState, useEffect } from 'react';
+
+const CACHE_KEY = 'toasty_weather_news_cache';
+const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Hook to fetch weather-related news for a city using NewsData.io API
+ * Only fetches when enabled (typically when no alerts)
+ */
+export function useWeatherNews(cityName, enabled = true) {
+  const [news, setNews] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!enabled || !cityName) {
+      setNews([]);
+      setLoading(false);
+      return;
+    }
+
+    const fetchNews = async () => {
+      setLoading(true);
+      setError(null);
+
+      // Check cache first
+      const cacheKey = `${CACHE_KEY}_${cityName.toLowerCase().replace(/\s+/g, '_')}`;
+      const cached = localStorage.getItem(cacheKey);
+
+      if (cached) {
+        try {
+          const { data, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < CACHE_DURATION) {
+            setNews(data);
+            setLoading(false);
+            return;
+          }
+        } catch {
+          // Invalid cache, continue to fetch
+        }
+      }
+
+      const apiKey = import.meta.env.VITE_NEWSDATA_API_KEY;
+
+      if (!apiKey) {
+        console.warn('NewsData.io API key not configured');
+        setNews([]);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        // Search for weather-related news specific to the city
+        // Use category filter + city name for better relevance
+        const query = encodeURIComponent(`${cityName} weather`);
+        const url = `https://newsdata.io/api/1/latest?` +
+          `apikey=${apiKey}&` +
+          `q=${query}&` +
+          `country=us&` +
+          `language=en&` +
+          `category=top,environment`;
+
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`News API error: ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.status !== 'success') {
+          throw new Error(data.message || 'Failed to fetch news');
+        }
+
+        // Parse and normalize news items
+        const parsedNews = (data.results || [])
+          .slice(0, 5) // Limit to 5 items
+          .map((item) => ({
+            id: item.article_id || item.link,
+            title: item.title,
+            description: item.description,
+            source: item.source_name || item.source_id,
+            url: item.link,
+            imageUrl: item.image_url,
+            publishedAt: item.pubDate ? new Date(item.pubDate) : null,
+          }));
+
+        // Cache the results
+        localStorage.setItem(
+          cacheKey,
+          JSON.stringify({
+            data: parsedNews,
+            timestamp: Date.now(),
+          })
+        );
+
+        setNews(parsedNews);
+      } catch (err) {
+        console.error('Error fetching weather news:', err);
+        setError(err.message);
+        setNews([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNews();
+  }, [cityName, enabled]);
+
+  return { news, loading, error };
+}
+
+/**
+ * Format relative time for news items
+ */
+export function formatNewsTime(date) {
+  if (!date) return '';
+
+  // Handle both Date objects and date strings (from cache)
+  const dateObj = date instanceof Date ? date : new Date(date);
+  if (isNaN(dateObj.getTime())) return '';
+
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 1) return 'Just now';
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}


### PR DESCRIPTION
## Summary
- Add NewsData.io integration to show weather news when no active NWS alerts
- Create unified modal for viewing all alerts and news details
- Cache news results for 30 minutes to conserve API quota (200 requests/day)

## Features
- **Weather News Hook**: `useWeatherNews` fetches city-specific weather news
- **Smart Query**: Filters by `{cityName} weather` + environment category for relevant results
- **AlertsNewsModal**: Full-screen modal with alerts section + news section
- **Clickable Widget**: Tap anywhere on widget to open detailed modal

## Widget States
| State | Display |
|-------|---------|
| Loading alerts | Spinner |
| Has alerts | Alert cards (click opens modal) |
| No alerts + Loading news | "No Alerts" badge + spinner |
| No alerts + Has news | News headlines (click opens modal) |
| No alerts + No news | "No Active Alerts" message |

## Test plan
- [ ] Navigate to a city with no active NWS alerts
- [ ] Verify weather news headlines appear in the widget
- [ ] Click widget to open modal with full news details
- [ ] Verify news is relevant to the specific city
- [ ] Navigate to a city WITH alerts and verify alert display still works
- [ ] Click alert widget to verify modal shows both alerts and news

🤖 Generated with [Claude Code](https://claude.com/claude-code)