### PR TITLE
Phase 3: Improve loading states and indicators

### DIFF
--- a/src/components/home/InteractiveMarketsMap.jsx
+++ b/src/components/home/InteractiveMarketsMap.jsx
@@ -124,6 +124,7 @@ export default function InteractiveMarketsMap() {
   const navigate = useNavigate();
   const [hoveredCity, setHoveredCity] = useState(null);
   const [cityWeather, setCityWeather] = useState({});
+  const [weatherLoading, setWeatherLoading] = useState(true);
   const isMobile = window.innerWidth < 768;
 
   // View mode state
@@ -205,6 +206,7 @@ export default function InteractiveMarketsMap() {
     };
 
     const fetchAllWeather = async () => {
+      setWeatherLoading(true);
       const weatherData = {};
       await Promise.all(
         MARKET_CITIES.map(async (city) => {
@@ -215,6 +217,7 @@ export default function InteractiveMarketsMap() {
         })
       );
       setCityWeather(weatherData);
+      setWeatherLoading(false);
     };
 
     fetchAllWeather();
@@ -339,8 +342,10 @@ export default function InteractiveMarketsMap() {
                         <div className="text-xl font-bold text-orange-500">
                           {Math.round((cityWeather[city.slug].currentTemp * 9/5) + 32)}°
                         </div>
+                      ) : weatherLoading ? (
+                        <div className="w-4 h-4 border-2 border-orange-200 border-t-orange-500 rounded-full animate-spin mx-auto" />
                       ) : (
-                        <div className="text-xs">...</div>
+                        <div className="text-xs text-gray-400">--</div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

Phase 3 from the optimization plan - improved loading states across the app.

### Changes
- Added `weatherLoading` state to InteractiveMarketsMap
- Show spinning loader in city tooltips while weather data loads
- Show "--" fallback when weather data unavailable (after loading fails)

### Existing Loading States (already good)
Reviewed and confirmed these already have proper loading:
- **MarketBracketsModal** - spinner for charts, skeleton for orderbook
- **MultiBracketChart** - spinner while loading price history  
- **ObservationDetailModal** - receives data from parent, handles empty states
- **RoundingModal** - no async data, all local calculations
- **CityDashboard** - each widget handles its own loading state

## Test plan
- [ ] Hover over city markers on map - should see spinner while loading
- [ ] After load completes, should see temperature
- [ ] If weather fails to load, should see "--" instead of spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)