### PR TITLE
Phase 4: Performance optimizations

### DIFF
--- a/src/components/dashboard/WidgetRenderer.jsx
+++ b/src/components/dashboard/WidgetRenderer.jsx
@@ -1,5 +1,5 @@
-import { Suspense, useState } from 'react';
-import { X, GripVertical, RefreshCw } from 'lucide-react';
+import { Suspense, useState, useMemo } from 'react';
+import { X, RefreshCw } from 'lucide-react';
 import { getWidget } from '../../config/WidgetRegistry';
 import { CITY_BY_SLUG } from '../../config/cities';
 
@@ -30,8 +30,8 @@ export default function WidgetRenderer({
 
   const Component = widgetConfig.component;
 
-  // Resolve props based on widget requirements
-  const resolveProps = () => {
+  // Resolve props based on widget requirements - memoized to prevent unnecessary recalculations
+  const widgetProps = useMemo(() => {
     const props = {};
 
     widgetConfig.requiredProps.forEach(prop => {
@@ -57,9 +57,7 @@ export default function WidgetRenderer({
     });
 
     return props;
-  };
-
-  const widgetProps = resolveProps();
+  }, [widgetConfig.requiredProps, city, citySlug]);
 
   return (
     <div

--- a/src/components/weather/SmallWidgets.jsx
+++ b/src/components/weather/SmallWidgets.jsx
@@ -1,4 +1,4 @@
-import { useState, memo } from 'react';
+import { useState, memo, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import {
   Sun,
@@ -14,7 +14,9 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import GlassWidget from './GlassWidget';
-import WindDetailModal from './WindDetailModal';
+
+// Lazy load modal with Recharts
+const WindDetailModal = lazy(() => import('./WindDetailModal'));
 
 /**
  * Small Weather Widgets - Apple Weather inspired compact widgets
@@ -246,17 +248,21 @@ export const WindWidget = memo(function WindWidget({
           </div>
         </GlassWidget>
 
-        {/* Wind Detail Modal */}
-        <WindDetailModal
-          isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-          currentSpeed={speedMph}
-          currentDirection={directionDeg}
-          currentGusts={gustsMph}
-          observations={observations}
-          timezone={timezone}
-          cityName={cityName}
-        />
+        {/* Wind Detail Modal - Lazy loaded */}
+        {isModalOpen && (
+          <Suspense fallback={null}>
+            <WindDetailModal
+              isOpen={isModalOpen}
+              onClose={() => setIsModalOpen(false)}
+              currentSpeed={speedMph}
+              currentDirection={directionDeg}
+              currentGusts={gustsMph}
+              observations={observations}
+              timezone={timezone}
+              cityName={cityName}
+            />
+          </Suspense>
+        )}
       </>
     );
   }
@@ -302,17 +308,21 @@ export const WindWidget = memo(function WindWidget({
         </div>
       </GlassWidget>
 
-      {/* Wind Detail Modal */}
-      <WindDetailModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        currentSpeed={speedMph}
-        currentDirection={directionDeg}
-        currentGusts={gustsMph}
-        observations={observations}
-        timezone={timezone}
-        cityName={cityName}
-      />
+      {/* Wind Detail Modal - Lazy loaded */}
+      {isModalOpen && (
+        <Suspense fallback={null}>
+          <WindDetailModal
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            currentSpeed={speedMph}
+            currentDirection={directionDeg}
+            currentGusts={gustsMph}
+            observations={observations}
+            timezone={timezone}
+            cityName={cityName}
+          />
+        </Suspense>
+      )}
     </>
   );
 });


### PR DESCRIPTION
## Summary

Phase 4 from the optimization plan - performance improvements.

### Changes
- **useMemo for WidgetRenderer** - Memoize `resolveProps` to prevent recalculation on every render
- **Lazy load WindDetailModal** - Code-split the modal with Recharts charts using `React.lazy()` and `Suspense`
- **Cleanup** - Remove unused `GripVertical` import

### Bundle Size Impact
- Main bundle: 882KB → 873KB (**~9KB reduction**)
- WindDetailModal now loads as separate chunk (9.36KB)

### Skipped Items
- Virtualization for HomePageMarkets/AllMarketsModal - only 7-20 items, not worth the complexity
- WeatherMap useCallback - handlers are inside useEffect or are simple state setters

## Test plan
- [ ] Wind widget modal should open without issues
- [ ] WidgetRenderer should work correctly with memoized props
- [ ] Build passes with smaller bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)