### PR TITLE
Phase 5: Mobile responsiveness improvements

### DIFF
--- a/src/components/home/AllMarketsModal.jsx
+++ b/src/components/home/AllMarketsModal.jsx
@@ -70,7 +70,7 @@ export default function AllMarketsModal({
       />
 
       {/* Modal */}
-      <div className="fixed inset-4 md:inset-8 lg:inset-16 z-[100] flex items-center justify-center">
+      <div className="fixed inset-2 md:inset-8 lg:inset-16 z-[100] flex items-center justify-center">
         <div className="glass-elevated w-full max-w-4xl max-h-full overflow-hidden flex flex-col">
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-white/10">

--- a/src/components/home/InteractiveMarketsMap.jsx
+++ b/src/components/home/InteractiveMarketsMap.jsx
@@ -290,7 +290,7 @@ export default function InteractiveMarketsMap() {
 
       {/* Content Area - Map or Satellite */}
       {viewMode === 'markets' ? (
-        <div className="h-[450px] md:h-[400px] sm:h-[350px] rounded-2xl overflow-hidden
+        <div className="min-h-[300px] h-[min(60vh,450px)] md:h-[min(50vh,400px)] rounded-2xl overflow-hidden
                         border border-[var(--color-border)] shadow-lg markets-map-container relative">
           <MapContainer
             center={[39.8283, -98.5795]}

--- a/src/components/weather/HourlyForecast.jsx
+++ b/src/components/weather/HourlyForecast.jsx
@@ -176,7 +176,7 @@ export default function HourlyForecast({
         icon={Clock}
         size="medium"
       >
-        <div className="flex gap-0 overflow-x-auto glass-scroll pb-1 -mx-1 px-1">
+        <div className="flex gap-0 overflow-x-auto glass-scroll pb-1 -mx-1 px-1 snap-x snap-mandatory">
           {displayData.map((obs, index) => {
             const isMostRecent = index === 0;
             const Icon = getConditionIcon(obs.description, isDaytime(obs.timestamp, timezone));
@@ -186,7 +186,7 @@ export default function HourlyForecast({
                 key={obs.time}
                 onClick={() => setSelectedIndex(index)}
                 className={`
-                  flex flex-col items-center min-w-[48px] py-1 px-0.5 rounded-xl
+                  flex flex-col items-center min-w-[48px] py-1 px-0.5 rounded-xl snap-start
                   transition-all hover:bg-white/10 active:scale-95
                   ${isMostRecent ? 'bg-white/10' : ''}
                 `}

--- a/src/components/weather/MapWidgetPopup.jsx
+++ b/src/components/weather/MapWidgetPopup.jsx
@@ -373,7 +373,7 @@ export default function MapWidgetPopup({
           <div className="absolute top-0 left-0 right-0 z-[60] flex items-center justify-between px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
             <button
               onClick={onClose}
-              className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+              className="w-11 h-11 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 transition-colors"
             >
               <X className="w-5 h-5 text-white" />
             </button>
@@ -520,13 +520,13 @@ export default function MapWidgetPopup({
               <div className="flex items-center gap-3 mb-3">
                 <button
                   onClick={() => setIsPlaying(p => !p)}
-                  className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+                  className="w-11 h-11 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 transition-colors"
                   disabled={frames.length === 0}
                 >
                   {isPlaying ? (
-                    <Pause className="w-4 h-4 text-white" />
+                    <Pause className="w-5 h-5 text-white" />
                   ) : (
-                    <Play className="w-4 h-4 text-white" />
+                    <Play className="w-5 h-5 text-white" />
                   )}
                 </button>
                 <span className="text-sm text-white/80">


### PR DESCRIPTION
## Summary
- Fix touch targets in MapWidgetPopup (44x44px for close and play/pause buttons)
- Improve modal spacing on mobile in AllMarketsModal (inset-2 on mobile)
- Add snap scrolling to HourlyForecast for better mobile UX
- Use viewport-relative sizing for InteractiveMarketsMap

## Notes
- CityCard already had proper 44px touch targets (w-11 h-11)
- MarketBracketsModal already used responsive padding (p-2 sm:p-4)
- Changes are minimal - most components already had good mobile support

## Test plan
- [ ] Test touch targets on mobile device
- [ ] Verify modal spacing on small screens
- [ ] Test horizontal scrolling in HourlyForecast
- [ ] Check map height on different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)