### PR TITLE
Remove trading advice from copilot AI, make it analysis-only

### DIFF
--- a/prompts/copilot-system.js
+++ b/prompts/copilot-system.js
@@ -1,20 +1,21 @@
 /**
  * Copilot System Prompt
  *
- * Comprehensive instructions for the weather trading AI assistant.
- * This prompt is designed for Kalshi temperature prediction markets.
+ * Instructions for the weather analysis AI assistant.
+ * Provides factual analysis for Kalshi temperature prediction markets.
+ * Does NOT provide trading advice (buy/sell recommendations).
  */
 
 import { retrieveKnowledge, formatKnowledgeForPrompt } from '../src/data/weatherKnowledge.js';
 
-export const COPILOT_SYSTEM_PROMPT = `You are a weather research copilot for Kalshi temperature prediction market trading. You help traders analyze weather data, understand market odds, and build profitable trading theses.
+export const COPILOT_SYSTEM_PROMPT = `You are a weather research copilot for Kalshi temperature prediction market traders. You help traders analyze weather data and understand how current conditions relate to market settlement. You provide factual analysis only - never trading advice.
 
 ## Your Role
 - Analyze real-time weather observations and forecasts
-- Identify trading opportunities in temperature markets
-- Explain market pricing and why brackets have certain odds
-- Help users understand when markets are mispriced
-- Write concise research notes and trading theses
+- Explain how temperature markets work and what drives bracket pricing
+- Summarize current conditions, trends, and forecast data
+- Write concise research notes based on factual weather analysis
+- NEVER give trading advice (no buy/sell/hold recommendations)
 
 ## CRITICAL: Response Length
 - Keep ALL responses under 150 words
@@ -128,21 +129,20 @@ Real-time 5-minute data showing 79°F all afternoon might settle at 78°F in the
 - If "High So Far Today" shows 67°F, the settlement will be AT LEAST 67°F
 - If temperature is currently FALLING, the high is likely LOCKED IN
 - A bracket containing the current high + falling temps = near certain winner
-- NEVER recommend selling a bracket that contains the high so far when temps are falling
+- When analyzing, always note whether the high appears locked in or if higher temps are still possible
 
 ### Example of CORRECT Analysis
 - High so far: 67°F (reached at 9:53am)
 - Current temp: 63°F and falling
 - 67-68° bracket at 90%
-- **CORRECT:** 90% is FAIR because 67°F was already hit and temps are falling. Settlement will almost certainly be 67°F.
-- **WRONG:** "67-68° is overpriced, sell it" - NO! The high was already reached!
+- **CORRECT:** Note that 67°F was already hit and temps are falling. Settlement will almost certainly be 67°F. The bracket containing 67°F is very likely to win.
 
 ### Example of INCORRECT Analysis (DO NOT DO THIS)
 - Seeing current temp 63°F and concluding 67-68° won't hit
 - Ignoring that 67°F was already recorded earlier in the day
-- Recommending selling a bracket that's almost certain to win
+- Failing to check the "High So Far" before analyzing settlement probabilities
 
-## Trading Signals
+## Key Analysis Indicators
 
 ### When High is Likely Locked In
 - Temperature is FALLING from earlier peak
@@ -156,10 +156,10 @@ Real-time 5-minute data showing 79°F all afternoon might settle at 78°F in the
 - Forecast shows higher temps expected later
 - The current high may not be the final high
 
-### Rounding Edge Signals
+### Rounding Considerations
 - When displayed temp is at X.8°F or X.9°F, actual is likely lower
 - CLI often comes in 1°F below what 5-minute data suggested
-- But rounding works BOTH ways - 67.4°F displayed might be 67°F or 68°F in CLI
+- Rounding works BOTH ways - 67.4°F displayed might be 67°F or 68°F in CLI
 
 ## Weather Analysis Framework
 
@@ -175,24 +175,24 @@ Real-time 5-minute data showing 79°F all afternoon might settle at 78°F in the
 - When models differ by 3°F+ = uncertainty, spreads should be wider
 - NBM (National Blend of Models) is usually most accurate for temperature
 
-## Output Guidelines
+## Output Format
 
 ### Format Rules
 - 3-5 bullet points MAX
 - No introductions or conclusions
 - Numbers > words (use actual temps, prices, times)
-- Bold the key recommendation
+- Bold the key finding
 
 ### Example Response (this length is MAXIMUM):
 
-**67-68° at 90% is CORRECTLY priced**
+**67-68° bracket analysis**
 - High so far: 67°F (hit at 9:53am)
 - Current: 63°F and falling with light rain
-- High is locked in - temps won't exceed 67°F today
-- Settlement almost certain to be 67°F
-- No trading edge here, market is efficient
+- High appears locked in - temps unlikely to exceed 67°F today
+- Settlement would be 67°F if no further warming occurs
+- Market pricing: 67-68° at 90%
 
-Use this format. Never exceed this length.`;
+Use this format. Never exceed this length. Do NOT recommend buying or selling.`;
 
 /**
  * Build the full system prompt with dynamic context

--- a/src/components/home/AlertsBanner.jsx
+++ b/src/components/home/AlertsBanner.jsx
@@ -1,0 +1,188 @@
+import { useState, useEffect, useMemo } from 'react';
+import { AlertTriangle, ChevronRight, X } from 'lucide-react';
+import { MARKET_CITIES } from '../../config/cities';
+import { getAlertColor, getAlertIcon } from '../../hooks/useNWSAlerts';
+
+/**
+ * AlertsBanner - Horizontal scrolling alert feed across all market cities
+ * Renders nothing when no alerts are active
+ */
+export default function AlertsBanner() {
+  const [allAlerts, setAllAlerts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedAlert, setExpandedAlert] = useState(null);
+
+  // Fetch alerts for all market cities
+  useEffect(() => {
+    const fetchAllAlerts = async () => {
+      setLoading(true);
+
+      const alertPromises = MARKET_CITIES.map(async (city) => {
+        try {
+          const response = await fetch(
+            `https://api.weather.gov/alerts/active?point=${city.lat},${city.lon}`,
+            { headers: { 'User-Agent': 'Toasty Research App' } }
+          );
+
+          if (!response.ok) return [];
+
+          const data = await response.json();
+          return (data.features || []).map((feature) => ({
+            id: feature.properties.id,
+            event: feature.properties.event,
+            headline: feature.properties.headline,
+            description: feature.properties.description,
+            severity: feature.properties.severity,
+            expires: feature.properties.expires ? new Date(feature.properties.expires) : null,
+            cityName: city.name,
+            citySlug: city.slug,
+          }));
+        } catch (err) {
+          console.error(`Error fetching alerts for ${city.name}:`, err);
+          return [];
+        }
+      });
+
+      const results = await Promise.all(alertPromises);
+      const combined = results.flat();
+
+      // Deduplicate by alert ID and sort by severity
+      const unique = Array.from(new Map(combined.map(a => [a.id, a])).values());
+      const severityOrder = { Extreme: 0, Severe: 1, Moderate: 2, Minor: 3, Unknown: 4 };
+      unique.sort((a, b) => (severityOrder[a.severity] || 4) - (severityOrder[b.severity] || 4));
+
+      setAllAlerts(unique);
+      setLoading(false);
+    };
+
+    fetchAllAlerts();
+
+    // Refresh every 5 minutes
+    const interval = setInterval(fetchAllAlerts, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Don't render anything if no alerts
+  if (!loading && allAlerts.length === 0) {
+    return null;
+  }
+
+  // Loading state - minimal skeleton
+  if (loading) {
+    return null; // Don't show loading state for alerts banner
+  }
+
+  return (
+    <>
+      <div className="w-full max-w-6xl mx-auto px-4 mt-3">
+        <div className="glass-widget py-2 px-3 flex items-center gap-3 overflow-hidden">
+          {/* Alert indicator */}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            <AlertTriangle className="w-4 h-4 text-amber-400" />
+            <span className="text-[10px] text-white/50 uppercase tracking-wide font-medium hidden sm:block">
+              Alerts
+            </span>
+            <span className="px-1.5 py-0.5 bg-amber-500/20 text-amber-400 text-[10px] font-bold rounded">
+              {allAlerts.length}
+            </span>
+          </div>
+
+          {/* Divider */}
+          <div className="h-5 w-px bg-white/10 flex-shrink-0" />
+
+          {/* Scrolling alert chips */}
+          <div className="flex-1 overflow-x-auto scrollbar-hide">
+            <div className="flex gap-2">
+              {allAlerts.map((alert) => {
+                const colors = getAlertColor(alert.severity);
+                return (
+                  <button
+                    key={alert.id}
+                    onClick={() => setExpandedAlert(alert)}
+                    className={`
+                      flex items-center gap-1.5 px-2.5 py-1 rounded-lg flex-shrink-0
+                      ${colors.bg} border ${colors.border}
+                      hover:scale-105 transition-transform cursor-pointer
+                    `}
+                  >
+                    <span className="text-sm">{getAlertIcon(alert.event)}</span>
+                    <span className={`text-xs font-medium ${colors.text}`}>
+                      {alert.cityName}
+                    </span>
+                    <span className="text-[10px] text-white/60 max-w-[100px] truncate">
+                      {alert.event}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Expanded Alert Modal */}
+      {expandedAlert && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+          onClick={() => setExpandedAlert(null)}
+        >
+          <div
+            className="glass-elevated max-w-lg w-full max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Modal Header */}
+            <div className="flex items-start justify-between p-4 border-b border-white/10">
+              <div className="flex items-center gap-3">
+                <span className="text-2xl">{getAlertIcon(expandedAlert.event)}</span>
+                <div>
+                  <h3 className="text-lg font-bold text-white">{expandedAlert.event}</h3>
+                  <p className="text-sm text-white/60">{expandedAlert.cityName}</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setExpandedAlert(null)}
+                className="p-2 rounded-lg hover:bg-white/10 transition-colors"
+              >
+                <X className="w-5 h-5 text-white/60" />
+              </button>
+            </div>
+
+            {/* Modal Content */}
+            <div className="p-4 space-y-4">
+              {/* Severity Badge */}
+              <div className="flex items-center gap-2">
+                {(() => {
+                  const colors = getAlertColor(expandedAlert.severity);
+                  return (
+                    <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${colors.bg} ${colors.text}`}>
+                      {expandedAlert.severity}
+                    </span>
+                  );
+                })()}
+                {expandedAlert.expires && (
+                  <span className="text-xs text-white/40">
+                    Expires: {expandedAlert.expires.toLocaleString()}
+                  </span>
+                )}
+              </div>
+
+              {/* Headline */}
+              {expandedAlert.headline && (
+                <p className="text-sm text-white/80 font-medium">
+                  {expandedAlert.headline}
+                </p>
+              )}
+
+              {/* Description */}
+              {expandedAlert.description && (
+                <div className="text-xs text-white/60 whitespace-pre-wrap leading-relaxed max-h-[300px] overflow-y-auto">
+                  {expandedAlert.description}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/home/DataCountdownBar.jsx
+++ b/src/components/home/DataCountdownBar.jsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useContext, useMemo } from 'react';
+import { FileText, Clock, Radio } from 'lucide-react';
+import { MARKET_CITIES } from '../../config/cities';
+import { KalshiMarketsContext } from '../../hooks/useAllKalshiMarkets';
+import { getNextCliRelease, getNextMetarRelease, formatCountdown } from '../../config/dataSchedule';
+
+/**
+ * DataCountdownBar - Key timing information for traders
+ * Shows next CLI release, market close, and METAR across all cities
+ */
+export default function DataCountdownBar() {
+  const { marketsData = {} } = useContext(KalshiMarketsContext) || {};
+  const [now, setNow] = useState(new Date());
+
+  // Update every second for countdowns
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Find next CLI release across all market cities
+  const nextCli = useMemo(() => {
+    let earliest = null;
+    let earliestCity = null;
+
+    MARKET_CITIES.forEach(city => {
+      const target = getNextCliRelease(city.stationId);
+      if (target && (!earliest || target < earliest)) {
+        earliest = target;
+        earliestCity = city;
+      }
+    });
+
+    if (!earliest) return null;
+
+    const diff = earliest.getTime() - now.getTime();
+    return {
+      ...formatCountdown(diff),
+      city: earliestCity?.name,
+    };
+  }, [now]);
+
+  // Find next market close across all markets
+  const nextMarketClose = useMemo(() => {
+    let earliest = null;
+    let earliestCity = null;
+
+    Object.entries(marketsData).forEach(([slug, data]) => {
+      if (data?.closeTime) {
+        const closeDate = data.closeTime instanceof Date ? data.closeTime : new Date(data.closeTime);
+        if (!earliest || closeDate < earliest) {
+          earliest = closeDate;
+          earliestCity = MARKET_CITIES.find(c => c.slug === slug);
+        }
+      }
+    });
+
+    if (!earliest) return null;
+
+    const diff = earliest.getTime() - now.getTime();
+    if (diff <= 0) return { formatted: 'Closed', city: earliestCity?.name };
+
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+    return {
+      formatted: `${hours}h ${minutes}m ${seconds}s`,
+      hours,
+      city: earliestCity?.name,
+    };
+  }, [now, marketsData]);
+
+  // Find next METAR (typically ~:51-:56 past the hour)
+  const nextMetar = useMemo(() => {
+    // METAR is roughly the same for all stations - next :53 past the hour
+    const next = new Date(now);
+    next.setMinutes(53, 0, 0);
+    if (next <= now) {
+      next.setHours(next.getHours() + 1);
+    }
+
+    const diff = next.getTime() - now.getTime();
+    const minutes = Math.floor(diff / (1000 * 60));
+    const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+    return {
+      formatted: `${minutes}m ${seconds}s`,
+      minutes,
+    };
+  }, [now]);
+
+  // Get current time in each timezone
+  const timezones = useMemo(() => {
+    return [
+      { label: 'ET', tz: 'America/New_York' },
+      { label: 'CT', tz: 'America/Chicago' },
+      { label: 'MT', tz: 'America/Denver' },
+      { label: 'PT', tz: 'America/Los_Angeles' },
+    ].map(({ label, tz }) => ({
+      label,
+      time: now.toLocaleTimeString('en-US', {
+        timeZone: tz,
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      }),
+    }));
+  }, [now]);
+
+  return (
+    <div className="w-full max-w-6xl mx-auto px-4 pt-4">
+      <div className="glass-widget p-3">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          {/* Next CLI Release */}
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-blue-500/20 flex items-center justify-center flex-shrink-0">
+              <FileText className="w-3.5 h-3.5 text-blue-400" />
+            </div>
+            <div>
+              <p className="text-[9px] text-white/40 uppercase tracking-wide">Next CLI</p>
+              <p className={`text-sm font-bold tabular-nums ${
+                nextCli?.hours < 1 ? 'text-orange-400' : 'text-white'
+              }`}>
+                {nextCli?.formatted || '--'}
+              </p>
+            </div>
+            {nextCli?.city && (
+              <span className="text-[10px] text-white/30 hidden sm:block">
+                {nextCli.city}
+              </span>
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="h-8 w-px bg-white/10 hidden sm:block" />
+
+          {/* Next Market Close */}
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-orange-500/20 flex items-center justify-center flex-shrink-0">
+              <Clock className="w-3.5 h-3.5 text-orange-400" />
+            </div>
+            <div>
+              <p className="text-[9px] text-white/40 uppercase tracking-wide">Market Close</p>
+              <p className="text-sm font-bold text-orange-400 tabular-nums">
+                {nextMarketClose?.formatted || '--'}
+              </p>
+            </div>
+            {nextMarketClose?.city && (
+              <span className="text-[10px] text-white/30 hidden sm:block">
+                {nextMarketClose.city}
+              </span>
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="h-8 w-px bg-white/10 hidden sm:block" />
+
+          {/* Next METAR */}
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
+              <Radio className="w-3.5 h-3.5 text-emerald-400" />
+            </div>
+            <div>
+              <p className="text-[9px] text-white/40 uppercase tracking-wide">Next METAR</p>
+              <p className={`text-sm font-bold tabular-nums ${
+                nextMetar?.minutes < 5 ? 'text-emerald-400' : 'text-white'
+              }`}>
+                {nextMetar?.formatted || '--'}
+              </p>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="h-8 w-px bg-white/10 hidden lg:block" />
+
+          {/* Timezone Clocks */}
+          <div className="hidden lg:flex items-center gap-4">
+            {timezones.map(({ label, time }) => (
+              <div key={label} className="text-center min-w-[48px]">
+                <p className="text-[9px] text-white/40 font-medium">{label}</p>
+                <p className="text-xs font-medium text-white/70 tabular-nums">{time}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/FeaturedMarketCard.jsx
+++ b/src/components/home/FeaturedMarketCard.jsx
@@ -1,0 +1,230 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { TrendingUp } from 'lucide-react';
+import { CITY_BY_SLUG } from '../../config/cities';
+import { getWeatherBackground, WeatherOverlay } from '../weather/DynamicWeatherBackground';
+import { useAllCitiesWeather } from '../../hooks/useAllCitiesWeather';
+import { useKalshiMultiBracketHistory } from '../../hooks/useKalshiMultiBracketHistory';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+
+/**
+ * Condense bracket label for compact display
+ */
+function condenseLabel(label) {
+  if (!label) return '';
+  return label
+    .replace(/(\d+)°\s*(to|or)\s*(\d+)°/i, '$1-$3°')
+    .replace(/(\d+)°\s*or above/i, '≥$1°')
+    .replace(/(\d+)°\s*or below/i, '≤$1°');
+}
+
+/**
+ * FeaturedMarketCard - Larger featured card for highest-volume market
+ * Shows more data: current temp, price chart, 3 brackets
+ */
+export default function FeaturedMarketCard({ city }) {
+  const cityConfig = CITY_BY_SLUG[city?.slug];
+  const { getWeatherForCity } = useAllCitiesWeather();
+  const weather = getWeatherForCity(city?.slug);
+  const weatherBg = getWeatherBackground(weather?.condition, cityConfig?.timezone);
+
+  const [timer, setTimer] = useState(null);
+
+  const topBrackets = city?.topBrackets || [];
+  const allBrackets = city?.brackets || topBrackets;
+  const seriesTicker = city?.seriesTicker;
+  const totalVolume = city?.totalVolume;
+  const closeTime = city?.closeTime;
+
+  // Fetch price history for the line chart - show all brackets over 24h
+  const {
+    data: chartData,
+    legendData,
+    bracketColors,
+    loading: chartLoading,
+  } = useKalshiMultiBracketHistory(seriesTicker, allBrackets, '1d', allBrackets.length || 10, !!seriesTicker);
+
+  // Update timer every second
+  useEffect(() => {
+    const updateTimer = () => {
+      if (!closeTime) {
+        setTimer(null);
+        return;
+      }
+
+      const now = new Date();
+      const closeDate = closeTime instanceof Date ? closeTime : new Date(closeTime);
+      const diff = closeDate.getTime() - now.getTime();
+
+      if (diff <= 0) {
+        setTimer({ formatted: 'Closed' });
+        return;
+      }
+
+      const hours = Math.floor(diff / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+      setTimer({ formatted: `${hours}h ${minutes}m ${seconds}s` });
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+    return () => clearInterval(interval);
+  }, [closeTime]);
+
+  const formatVolume = (vol) => {
+    if (!vol) return '--';
+    if (vol >= 1000000) return `$${(vol / 1000000).toFixed(1)}M`;
+    if (vol >= 1000) return `$${Math.round(vol / 1000)}K`;
+    return `$${vol.toLocaleString()}`;
+  };
+
+  if (!city) return null;
+
+  return (
+    <Link
+      to={`/city/${city.slug}`}
+      className="glass-widget glass-interactive glass-animate-in block overflow-hidden relative card-featured"
+      style={{ background: weatherBg }}
+    >
+      <WeatherOverlay condition={weather?.condition} timezone={cityConfig?.timezone} index={0} />
+      <div className="absolute inset-0 bg-black/30" />
+
+      <div className="relative z-10 p-5">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <h3 className="text-2xl font-bold text-white drop-shadow-lg">
+              {city.name}
+            </h3>
+            <span className="text-[10px] px-2 py-1 rounded-full bg-blue-500/30 text-blue-300 font-medium border border-blue-500/30 flex items-center gap-1">
+              <TrendingUp className="w-3 h-3" />
+              Top Volume
+            </span>
+          </div>
+          {weather?.temperature && (
+            <div className="text-right">
+              <p className="text-[10px] text-white/50 uppercase">Current</p>
+              <p className="text-xl font-bold text-white tabular-nums drop-shadow-lg">
+                {Math.round(weather.temperature)}°F
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Price Chart + Brackets */}
+        {topBrackets.length > 0 ? (
+          <div className="mb-4">
+            {/* Price History Chart */}
+            <div className="h-[100px] mb-3 rounded-xl bg-gradient-to-b from-white/[0.03] to-white/[0.07] overflow-hidden border border-white/5 relative" style={{ minWidth: '200px' }}>
+              {chartLoading ? (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/20 z-10">
+                  <div className="w-5 h-5 border-2 border-white/20 border-t-white/50 rounded-full animate-spin" />
+                </div>
+              ) : chartData.length === 0 ? (
+                <div className="h-full flex items-center justify-center text-xs text-white/40">
+                  Price history unavailable
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height={100}>
+                  <LineChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 5 }}>
+                    <XAxis dataKey="timestamp" hide />
+                    <YAxis hide domain={[0, 100]} />
+                    <Tooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length) return null;
+                        const timeData = payload[0]?.payload;
+                        // Sort by value descending for tooltip
+                        const sortedPayload = [...payload].sort((a, b) => (b.value || 0) - (a.value || 0));
+                        return (
+                          <div className="bg-black/90 backdrop-blur-md px-3 py-2 rounded-lg text-[10px] shadow-xl border border-white/10">
+                            <div className="text-white/50 mb-1.5 text-[9px] uppercase tracking-wide">{timeData?.timeLabel}</div>
+                            <div className="space-y-1">
+                              {sortedPayload.map((entry, idx) => (
+                                <div key={idx} className="flex items-center gap-2">
+                                  <div className="w-2 h-2 rounded-full shadow-sm" style={{ backgroundColor: entry.color }} />
+                                  <span className="text-white/70 flex-1">{condenseLabel(entry.dataKey)}</span>
+                                  <span className="font-semibold text-white tabular-nums">{entry.value}%</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      }}
+                    />
+                    {legendData.map(({ label, color }, idx) => (
+                      <Line
+                        key={label}
+                        type="monotone"
+                        dataKey={label}
+                        stroke={color}
+                        strokeWidth={idx === 0 ? 2.5 : 2}
+                        strokeOpacity={idx === 0 ? 1 : 0.7}
+                        dot={false}
+                        activeDot={{ r: 4, fill: color, stroke: 'white', strokeWidth: 2 }}
+                      />
+                    ))}
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+
+            {/* Compact Bracket List */}
+            <div className="space-y-1.5">
+              {topBrackets.slice(0, 3).map((bracket, i) => {
+                const color = bracketColors[bracket.label] || '#3B82F6';
+                return (
+                  <div
+                    key={bracket.ticker || i}
+                    className="relative flex items-center justify-between py-2 px-3 rounded-lg"
+                  >
+                    <div
+                      className="absolute left-0 top-0 bottom-0 rounded-lg opacity-25"
+                      style={{ width: `${bracket.yesPrice}%`, backgroundColor: color }}
+                    />
+                    <div className="relative flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+                      <span className="text-sm font-medium text-white">
+                        {condenseLabel(bracket.label)}
+                      </span>
+                    </div>
+                    <div className="relative flex items-center gap-2">
+                      <span className="text-sm font-bold text-white tabular-nums">
+                        {bracket.yesPrice}%
+                      </span>
+                      <div className="flex rounded-md overflow-hidden text-[9px] font-medium">
+                        <span className="px-1.5 py-0.5 bg-purple-500/20 text-purple-400">Yes</span>
+                        <span className="px-1.5 py-0.5 bg-white/10 text-white/50">No</span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="h-[180px] flex items-center justify-center text-sm text-white/40 mb-4">
+            Loading market data...
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between pt-3 border-t border-white/15">
+          <span className="text-sm font-medium text-white/70">{formatVolume(totalVolume)}</span>
+          {timer && (
+            <span className="text-sm font-bold text-orange-400 tabular-nums">
+              {timer.formatted}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/home/HomePageMarkets.jsx
+++ b/src/components/home/HomePageMarkets.jsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { TrendingUp, CloudRain, Snowflake } from 'lucide-react';
+import { TrendingUp, CloudRain, Snowflake, BarChart3, Maximize2 } from 'lucide-react';
 import { MARKET_CITIES, CITY_BY_SLUG } from '../../config/cities';
 import { KalshiMarketsContext, useLowTempMarkets } from '../../hooks/useAllKalshiMarkets.jsx';
 import { useKalshiRainMarkets } from '../../hooks/useKalshiRainMarkets';
@@ -8,6 +8,11 @@ import { useKalshiSnowMarkets } from '../../hooks/useKalshiSnowMarkets';
 import { useAllCitiesWeather } from '../../hooks/useAllCitiesWeather';
 import { getWeatherBackground, WeatherOverlay } from '../weather/DynamicWeatherBackground';
 import MarketCardGlass from './MarketCardGlass';
+import DataCountdownBar from './DataCountdownBar';
+import AlertsBanner from './AlertsBanner';
+import SatellitePreview from './SatellitePreview';
+import FeaturedMarketCard from './FeaturedMarketCard';
+import NewsCards from './NewsCards';
 
 /**
  * HomePageMarkets - Markets-focused homepage
@@ -31,15 +36,6 @@ export default function HomePageMarkets() {
       .sort((a, b) => (b.totalVolume || 0) - (a.totalVolume || 0));
   }, [marketsData]);
 
-  // Format last update time
-  const formatLastUpdate = () => {
-    if (!lastFetch) return null;
-    return lastFetch.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-
   // Use real rain markets data, sorted by volume
   const rainMarkets = useMemo(() => {
     return rainMarketsData.length > 0 ? rainMarketsData : [];
@@ -50,13 +46,85 @@ export default function HomePageMarkets() {
     return snowMarketsData.length > 0 ? snowMarketsData : [];
   }, [snowMarketsData]);
 
+  // Calculate total market stats
+  const totalMarkets = sortedTempMarkets.length + rainMarkets.length + snowMarkets.length;
+  const totalVolume = useMemo(() => {
+    const tempVol = sortedTempMarkets.reduce((sum, m) => sum + (m.totalVolume || 0), 0);
+    const rainVol = rainMarkets.reduce((sum, m) => sum + (m.totalVolume || 0), 0);
+    const snowVol = snowMarkets.reduce((sum, m) => sum + (m.totalVolume || 0), 0);
+    return tempVol + rainVol + snowVol;
+  }, [sortedTempMarkets, rainMarkets, snowMarkets]);
+
+  const formatTotalVolume = (vol) => {
+    if (!vol) return '$0';
+    if (vol >= 1000000) return `$${(vol / 1000000).toFixed(1)}M`;
+    if (vol >= 1000) return `$${Math.round(vol / 1000)}K`;
+    return `$${vol.toLocaleString()}`;
+  };
+
+  // Find the featured market (highest volume)
+  const featuredMarket = sortedTempMarkets[0];
+  const remainingTempMarkets = sortedTempMarkets.slice(1);
+
+  // State for satellite modal
+  const [showSatelliteModal, setShowSatelliteModal] = useState(false);
+
   return (
     <div className="min-h-screen pb-24 md:pb-8 overflow-x-hidden w-full max-w-[100vw]">
-      {/* Temperature Markets Section */}
+      {/* Data Countdown Bar */}
+      <DataCountdownBar />
+
+      {/* Alerts Banner */}
+      <AlertsBanner />
+
+      {/* Hero Section */}
+      <div className="w-full max-w-6xl mx-auto px-4 pt-6 pb-2">
+        <div className="glass-animate-in">
+          {/* Eyebrow */}
+          <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/5 border border-white/10">
+              <BarChart3 className="w-3 h-3 text-blue-400" />
+              <span className="text-[10px] font-medium text-white/60 uppercase tracking-wide">
+                Weather Markets
+              </span>
+            </div>
+            {totalVolume > 0 && (
+              <span className="text-[10px] font-medium text-white/40">
+                {formatTotalVolume(totalVolume)} volume
+              </span>
+            )}
+          </div>
+
+          {/* Main headline */}
+          <h1 className="text-3xl md:text-4xl font-bold text-white tracking-tight mb-2">
+            Predict the weather
+          </h1>
+          <p className="text-sm md:text-base text-white/50 max-w-xl">
+            Trade on temperature, rain, and snow across major U.S. cities
+          </p>
+        </div>
+      </div>
+
+      {/* Featured Section: Satellite + Top Market */}
+      <div className="w-full max-w-6xl mx-auto px-4 pt-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {/* Satellite Preview */}
+          <SatellitePreview onExpand={() => setShowSatelliteModal(true)} />
+
+          {/* Featured Market Card */}
+          {featuredMarket && <FeaturedMarketCard city={featuredMarket} />}
+        </div>
+      </div>
+
+      {/* Temperature Markets Section (excluding featured) */}
       <TemperatureMarketsSection
-        highTempMarkets={sortedTempMarkets}
+        highTempMarkets={remainingTempMarkets}
         highTempLoading={tempLoading}
+        excludeFeatured={true}
       />
+
+      {/* News Cards */}
+      <NewsCards />
 
       {/* Rain Markets Section */}
       <PrecipitationSection
@@ -72,27 +140,53 @@ export default function HomePageMarkets() {
         loading={snowLoading}
       />
 
-      {/* Footer */}
-      <div className="w-full max-w-6xl mx-auto px-4 mt-8 text-center">
-        <p className="text-xs text-white/30">
-          Data provided by{' '}
-          <a
-            href="https://kalshi.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-white/50 hover:text-white/70 transition-colors"
-          >
-            Kalshi
-          </a>
-        </p>
-      </div>
+      {/* Satellite Modal */}
+      {showSatelliteModal && (
+        <SatelliteModal onClose={() => setShowSatelliteModal(false)} />
+      )}
 
+      {/* Footer */}
+      <footer className="w-full max-w-6xl mx-auto px-4 mt-12 pb-4">
+        <div className="pt-6 border-t border-white/5">
+          <p className="text-xs text-white/30 text-center">
+            Market data provided by{' '}
+            <a
+              href="https://kalshi.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/50 hover:text-white/70 transition-colors"
+            >
+              Kalshi
+            </a>
+          </p>
+        </div>
+      </footer>
     </div>
   );
 }
 
 /**
- * Toggle - Click to toggle between two options
+ * SectionHeader - Consistent section header with optional badge
+ */
+function SectionHeader({ children, badge, className = '' }) {
+  return (
+    <div className={`mb-6 ${className}`}>
+      <div className="flex items-baseline gap-3 flex-wrap">
+        <h2 className="text-xl md:text-2xl font-semibold text-white tracking-tight">
+          {children}
+        </h2>
+        {badge && (
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/8 text-white/50 font-medium">
+            {badge}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Toggle - Inline clickable toggle styled as part of heading text
  */
 function Toggle({ value, options, onChange }) {
   const currentIndex = options.findIndex(opt => opt.value === value);
@@ -106,7 +200,7 @@ function Toggle({ value, options, onChange }) {
   return (
     <button
       onClick={handleClick}
-      className="text-blue-400 font-semibold hover:text-blue-300 transition-colors cursor-pointer"
+      className="text-blue-400 hover:text-blue-300 transition-colors cursor-pointer underline decoration-blue-400/30 underline-offset-2 hover:decoration-blue-300/50"
     >
       {currentLabel}
     </button>
@@ -137,8 +231,8 @@ function TemperatureMarketsSection({ highTempMarkets, highTempLoading }) {
 
   // Market type options
   const typeOptions = [
-    { value: 'highest', label: 'Highest' },
-    { value: 'lowest', label: 'Lowest' },
+    { value: 'highest', label: 'highest' },
+    { value: 'lowest', label: 'lowest' },
   ];
 
   // Timeframe options
@@ -153,29 +247,18 @@ function TemperatureMarketsSection({ highTempMarkets, highTempLoading }) {
   // Check if we should show "coming soon" for tomorrow or lowest
   const showComingSoon = timeframe === 'tomorrow' || (!lowMarketsAvailable && marketType === 'lowest');
 
+  const marketCount = !loading && !showComingSoon && markets.length > 0 ? `${markets.length} markets` : null;
+
   return (
-    <div className="w-full max-w-6xl mx-auto px-4 pt-8">
-      {/* Dynamic Section Header */}
-      <div className="flex items-center gap-3 mb-6 flex-wrap">
-        <h1 className="text-2xl md:text-3xl font-bold text-white flex items-center gap-2 flex-wrap">
-          <Toggle
-            value={marketType}
-            options={typeOptions}
-            onChange={setMarketType}
-          />
-          <span className="text-white/80">temperature</span>
-          <Toggle
-            value={timeframe}
-            options={timeframeOptions}
-            onChange={setTimeframe}
-          />
-        </h1>
-        {!loading && !showComingSoon && markets.length > 0 && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/50">
-            {markets.length} markets
-          </span>
-        )}
-      </div>
+    <div className="w-full max-w-6xl mx-auto px-4 pt-6">
+      {/* Section Header - proper inline text flow */}
+      <SectionHeader badge={marketCount}>
+        <span className="text-white/60">What will be the </span>
+        <Toggle value={marketType} options={typeOptions} onChange={setMarketType} />
+        <span className="text-white/60"> temperature </span>
+        <Toggle value={timeframe} options={timeframeOptions} onChange={setTimeframe} />
+        <span className="text-white/60">?</span>
+      </SectionHeader>
 
       {/* Markets Grid */}
       {loading ? (
@@ -264,21 +347,16 @@ function PrecipitationSection({ type, markets, loading }) {
   }, [markets]);
 
   const noActiveMarkets = !loading && groupedMarkets.length === 0;
+  const cityCount = !loading && groupedMarkets.length > 0 ? `${groupedMarkets.length} cities` : null;
 
   return (
     <div className="w-full max-w-6xl mx-auto px-4 mt-10">
       {/* Section Header */}
-      <div className="flex items-center gap-3 mb-6 flex-wrap">
-        <h2 className="text-xl md:text-2xl font-bold text-white">
-          how much will it{' '}
-          <span className="text-blue-400">{type}</span>
-        </h2>
-        {!loading && groupedMarkets.length > 0 && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/50">
-            {groupedMarkets.length} cities
-          </span>
-        )}
-      </div>
+      <SectionHeader badge={cityCount}>
+        <span className="text-white/60">How much will it </span>
+        <span className="text-blue-400">{type}</span>
+        <span className="text-white/60">?</span>
+      </SectionHeader>
 
       {/* Markets Grid */}
       {loading ? (
@@ -461,69 +539,92 @@ function PrecipitationCard({ city, index }) {
 }
 
 /**
- * MarketSection - Reusable section for a market category
+ * SatelliteModal - Full-screen satellite imagery viewer
  */
-function MarketSection({
-  title,
-  icon: Icon,
-  markets,
-  loading,
-}) {
-  const noActiveMarkets = !loading && markets.length === 0;
-  return (
-    <div className="w-full max-w-6xl mx-auto px-4 mt-10">
-      {/* Section Header */}
-      <div className="flex items-center gap-2 mb-6">
-        <h2 className="text-xl md:text-2xl font-bold text-white">{title}</h2>
-        {!loading && markets.length > 0 && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/50">
-            {markets.length} markets
-          </span>
-        )}
-        {noActiveMarkets && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/50">
-            No Active Markets
-          </span>
-        )}
-      </div>
+function SatelliteModal({ onClose }) {
+  const [product, setProduct] = useState('geocolor');
+  const [cacheKey, setCacheKey] = useState(Date.now());
 
-      {/* Markets Grid */}
-      {loading ? (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="glass-widget animate-pulse">
-              <div className="h-20 bg-white/10" />
-              <div className="p-3">
-                <div className="h-3 w-32 bg-white/10 rounded mb-3" />
-                <div className="space-y-2 mb-3">
-                  <div className="h-9 bg-white/10 rounded-lg" />
-                  <div className="h-9 bg-white/10 rounded-lg" />
-                </div>
-                <div className="flex justify-between pt-2 border-t border-white/10">
-                  <div className="h-3 w-12 bg-white/10 rounded" />
-                  <div className="h-3 w-16 bg-white/10 rounded" />
-                </div>
-              </div>
-            </div>
-          ))}
+  const PRODUCTS = {
+    geocolor: {
+      name: 'Visible',
+      url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/GEOCOLOR/latest.jpg',
+    },
+    airmass: {
+      name: 'Air Mass',
+      url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/AirMass/latest.jpg',
+    },
+    infrared: {
+      name: 'Infrared',
+      url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/13/latest.jpg',
+    },
+    watervapor: {
+      name: 'Water Vapor',
+      url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/09/latest.jpg',
+    },
+  };
+
+  const currentProduct = PRODUCTS[product];
+  const imageUrl = `${currentProduct.url}?t=${cacheKey}`;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="glass-elevated max-w-5xl w-full max-h-[90vh] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-white/10">
+          <div className="flex items-center gap-3">
+            <Maximize2 className="w-5 h-5 text-white/50" />
+            <h3 className="text-lg font-semibold text-white">GOES-19 CONUS Satellite</h3>
+          </div>
+          <div className="flex items-center gap-2">
+            {Object.entries(PRODUCTS).map(([key, { name }]) => (
+              <button
+                key={key}
+                onClick={() => {
+                  setProduct(key);
+                  setCacheKey(Date.now());
+                }}
+                className={`text-xs px-3 py-1.5 rounded-full font-medium transition-colors cursor-pointer ${
+                  product === key
+                    ? 'bg-blue-500/80 text-white'
+                    : 'bg-white/10 text-white/60 hover:bg-white/20'
+                }`}
+              >
+                {name}
+              </button>
+            ))}
+          </div>
         </div>
-      ) : noActiveMarkets ? (
-        <div className="glass-widget p-8 text-center">
-          <Icon className="w-8 h-8 text-white/30 mx-auto mb-3" />
-          <p className="text-sm text-white/50">No active markets at this time</p>
-          <p className="text-xs text-white/30 mt-1">Check back later for new markets</p>
+
+        {/* Image */}
+        <div className="relative aspect-[16/10] bg-slate-900/50">
+          <img
+            src={imageUrl}
+            alt={`GOES-19 ${currentProduct.name}`}
+            className="w-full h-full object-contain"
+          />
         </div>
-      ) : (
-        <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {markets.map((market, index) => (
-            <MarketCardGlass
-              key={market.slug}
-              city={market}
-              index={index}
-            />
-          ))}
+
+        {/* Footer */}
+        <div className="p-3 flex items-center justify-between border-t border-white/10">
+          <span className="text-xs text-white/40">
+            Data: NOAA/NESDIS GOES-19 • Updated every 5 minutes
+          </span>
+          <button
+            onClick={onClose}
+            className="text-xs px-3 py-1.5 rounded-lg bg-white/10 text-white/70 hover:bg-white/20 transition-colors"
+          >
+            Close
+          </button>
         </div>
-      )}
+      </div>
     </div>
   );
 }
+

--- a/src/components/home/NewsCards.jsx
+++ b/src/components/home/NewsCards.jsx
@@ -1,0 +1,196 @@
+import { useState, useEffect } from 'react';
+import { Newspaper, ExternalLink } from 'lucide-react';
+
+const CACHE_KEY = 'toasty_homepage_news_cache';
+const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Format relative time for news items
+ */
+function formatNewsTime(date) {
+  if (!date) return '';
+
+  const dateObj = date instanceof Date ? date : new Date(date);
+  if (isNaN(dateObj.getTime())) return '';
+
+  const now = new Date();
+  const diffMs = now - dateObj;
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 1) return 'Just now';
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * NewsCards - Weather news articles displayed as cards
+ */
+export default function NewsCards() {
+  const [news, setNews] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      setLoading(true);
+
+      // Check cache first
+      const cached = localStorage.getItem(CACHE_KEY);
+      if (cached) {
+        try {
+          const { data, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < CACHE_DURATION) {
+            setNews(data);
+            setLoading(false);
+            return;
+          }
+        } catch {
+          // Invalid cache, continue to fetch
+        }
+      }
+
+      const apiKey = import.meta.env.VITE_NEWSDATA_API_KEY;
+
+      if (!apiKey) {
+        console.warn('NewsData.io API key not configured');
+        setNews([]);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        // Fetch general US weather news
+        const url = `https://newsdata.io/api/1/latest?` +
+          `apikey=${apiKey}&` +
+          `q=weather forecast&` +
+          `country=us&` +
+          `language=en&` +
+          `category=top,environment`;
+
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`News API error: ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.status !== 'success') {
+          throw new Error(data.message || 'Failed to fetch news');
+        }
+
+        const parsedNews = (data.results || [])
+          .slice(0, 4)
+          .map((item) => ({
+            id: item.article_id || item.link,
+            title: item.title,
+            description: item.description,
+            source: item.source_name || item.source_id,
+            url: item.link,
+            imageUrl: item.image_url,
+            publishedAt: item.pubDate ? new Date(item.pubDate) : null,
+          }));
+
+        // Cache results
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ data: parsedNews, timestamp: Date.now() })
+        );
+
+        setNews(parsedNews);
+      } catch (err) {
+        console.error('Error fetching weather news:', err);
+        setNews([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNews();
+  }, []);
+
+  // Don't render section if no API key or no news
+  if (!loading && news.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-6xl mx-auto px-4 mt-10">
+      {/* Section Header */}
+      <div className="flex items-center gap-2 mb-4">
+        <Newspaper className="w-4 h-4 text-white/40" />
+        <h2 className="text-sm font-medium text-white/60">Weather News</h2>
+      </div>
+
+      {/* Loading State */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="glass-widget p-3 animate-pulse">
+              <div className="aspect-[16/9] rounded-lg bg-white/5 mb-2" />
+              <div className="h-3 bg-white/10 rounded w-3/4 mb-2" />
+              <div className="h-2 bg-white/5 rounded w-full mb-1" />
+              <div className="h-2 bg-white/5 rounded w-2/3" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {news.map((article, index) => (
+            <a
+              key={article.id}
+              href={article.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`
+                glass-widget glass-interactive p-3 glass-animate-in
+                glass-delay-${(index % 5) + 1} group
+              `}
+            >
+              {/* Thumbnail */}
+              {article.imageUrl && (
+                <div className="aspect-[16/9] rounded-lg overflow-hidden mb-2 bg-white/5">
+                  <img
+                    src={article.imageUrl}
+                    alt=""
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                    onError={(e) => {
+                      e.target.style.display = 'none';
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Content */}
+              <div className="flex flex-col min-h-[80px]">
+                <h3 className="text-xs font-medium text-white line-clamp-2 mb-1 group-hover:text-blue-300 transition-colors">
+                  {article.title}
+                </h3>
+                {article.description && (
+                  <p className="text-[10px] text-white/50 line-clamp-2 mb-2 flex-grow">
+                    {article.description}
+                  </p>
+                )}
+                <div className="flex items-center justify-between mt-auto pt-2 border-t border-white/5">
+                  <span className="text-[9px] text-white/40 truncate max-w-[60%]">
+                    {article.source}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-[9px] text-white/40">
+                      {formatNewsTime(article.publishedAt)}
+                    </span>
+                    <ExternalLink className="w-2.5 h-2.5 text-white/30" />
+                  </div>
+                </div>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/home/SatellitePreview.jsx
+++ b/src/components/home/SatellitePreview.jsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from 'react';
+import { Satellite, RotateCw, Maximize2 } from 'lucide-react';
+
+const SATELLITE_PRODUCTS = {
+  geocolor: {
+    name: 'Visible',
+    url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/GEOCOLOR/latest.jpg',
+  },
+  airmass: {
+    name: 'Air Mass',
+    url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/AirMass/latest.jpg',
+  },
+  infrared: {
+    name: 'Infrared',
+    url: 'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/13/latest.jpg',
+  },
+};
+
+/**
+ * SatellitePreview - Compact GOES-19 satellite imagery for homepage
+ */
+export default function SatellitePreview({ onExpand }) {
+  const [product, setProduct] = useState('geocolor');
+  const [cacheKey, setCacheKey] = useState(Date.now());
+  const [lastUpdate, setLastUpdate] = useState(new Date());
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  // Auto-refresh every 5 minutes
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCacheKey(Date.now());
+      setLastUpdate(new Date());
+    }, 5 * 60 * 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleRefresh = (e) => {
+    e.stopPropagation();
+    setIsRefreshing(true);
+    setImageLoaded(false);
+    setCacheKey(Date.now());
+    setLastUpdate(new Date());
+    setTimeout(() => setIsRefreshing(false), 500);
+  };
+
+  const handleProductChange = (e, newProduct) => {
+    e.stopPropagation();
+    setImageLoaded(false);
+    setProduct(newProduct);
+    setCacheKey(Date.now());
+  };
+
+  const formatTime = (date) => {
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  const currentProduct = SATELLITE_PRODUCTS[product];
+  const imageUrl = `${currentProduct.url}?t=${cacheKey}`;
+
+  return (
+    <div
+      className="glass-widget glass-interactive overflow-hidden cursor-pointer group glass-animate-in"
+      onClick={onExpand}
+    >
+      {/* Compact Header */}
+      <div className="flex items-center justify-between px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <Satellite className="w-3 h-3 text-white/50" />
+          <span className="text-[10px] text-white/50 uppercase tracking-wide font-medium">
+            GOES-19
+          </span>
+        </div>
+
+        {/* Product Selector */}
+        <div className="flex gap-1">
+          {Object.entries(SATELLITE_PRODUCTS).map(([key, { name }]) => (
+            <button
+              key={key}
+              onClick={(e) => handleProductChange(e, key)}
+              className={`text-[9px] px-2 py-0.5 rounded-full font-medium transition-colors cursor-pointer ${
+                product === key
+                  ? 'bg-blue-500/80 text-white'
+                  : 'bg-white/20 text-white/60 hover:bg-white/30'
+              }`}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Image Container */}
+      <div className="relative aspect-[16/10] bg-slate-900/50">
+        {/* Loading Skeleton */}
+        {!imageLoaded && (
+          <div className="absolute inset-0 bg-white/5 animate-pulse flex items-center justify-center">
+            <Satellite className="w-8 h-8 text-white/20 animate-pulse" />
+          </div>
+        )}
+
+        {/* Satellite Image */}
+        <img
+          src={imageUrl}
+          alt={`GOES-19 ${currentProduct.name}`}
+          className={`w-full h-full object-cover transition-opacity duration-300 ${
+            imageLoaded ? 'opacity-100' : 'opacity-0'
+          }`}
+          loading="lazy"
+          onLoad={() => setImageLoaded(true)}
+        />
+
+        {/* Hover Overlay */}
+        <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-black/50">
+            <Maximize2 className="w-4 h-4 text-white/80" />
+            <span className="text-xs text-white/80">Click to expand</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 py-1.5 flex items-center justify-between">
+        <span className="text-[10px] text-white/40">
+          Updated {formatTime(lastUpdate)}
+        </span>
+        <button
+          onClick={handleRefresh}
+          className="p-1 rounded hover:bg-white/10 transition-colors"
+        >
+          <RotateCw className={`w-3 h-3 text-white/40 hover:text-white/60 ${
+            isRefreshing ? 'animate-spin' : ''
+          }`} />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Updated the copilot system prompt to focus on factual weather analysis rather than trading recommendations
- The AI will no longer suggest buying/selling brackets or claim markets are mispriced
- Changed example responses to show analysis without buy/sell recommendations
- Renamed sections from "Trading Signals" to "Key Analysis Indicators"

## Test plan
- [ ] Test copilot with various queries to verify it provides analysis without trading advice
- [ ] Verify the AI still explains market mechanics and settlement rules
- [ ] Confirm responses stay within the 150 word limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)