### PR TITLE
Add draggable and resizable widgets to city dashboard

### DIFF
--- a/src/components/dashboard/CityDashboardNew.jsx
+++ b/src/components/dashboard/CityDashboardNew.jsx
@@ -19,7 +19,6 @@ import {
   MarketBrackets,
   NWSDiscussionWidget,
   ModelsWidget,
-  WidgetGridV2,
   WeatherMap,
   WindWidget,
   ResolutionWidget,
@@ -27,6 +26,7 @@ import {
   NearbyStations,
   AlertsWidget,
 } from '../weather';
+import CityWidgetGrid from './CityWidgetGrid';
 import RainWidget from '../widgets/RainWidget';
 import RainSnowBracketsWidget from '../widgets/RainSnowBracketsWidget';
 
@@ -274,11 +274,21 @@ function CityDashboardContent({ city, citySlug }) {
         />
       </div>
 
-      {/* Widget Grid V2 - CSS Grid with named areas */}
+      {/* Widget Grid - Draggable & Resizable */}
       <div className="w-full max-w-5xl mx-auto px-2 sm:px-3 mt-2 pb-4">
-        <WidgetGridV2 expandedWidgets={expandedWidgets} absentWidgets={absentWidgets}>
-          {/* Models Widget - 2x2 square */}
-          <WidgetGridV2.Area area="models" isExpanded={expandedWidgets.models}>
+        <CityWidgetGrid
+          citySlug={citySlug}
+          expandedWidgets={expandedWidgets}
+          onExpansionChange={(widgetId, shouldExpand) => {
+            setExpandedWidgets(prev => ({
+              ...prev,
+              [widgetId]: shouldExpand
+            }));
+          }}
+          absentWidgets={absentWidgets}
+        >
+          {/* Models Widget */}
+          <div key="models" area="models" className="h-full">
             <ModelsWidget
               citySlug={citySlug}
               lat={city.lat}
@@ -287,23 +297,10 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.models}
               onToggleExpand={() => toggleExpansion('models')}
             />
-          </WidgetGridV2.Area>
-
-          {/* Alerts Widget - 1x1, conditionally shown */}
-          {alerts && alerts.length > 0 && (
-            <WidgetGridV2.Area area="alerts" isExpanded={expandedWidgets.alerts}>
-              <AlertsWidget
-                lat={city.lat}
-                lon={city.lon}
-                cityName={city.name}
-                isExpanded={expandedWidgets.alerts}
-                onToggleExpand={() => toggleExpansion('alerts')}
-              />
-            </WidgetGridV2.Area>
-          )}
+          </div>
 
           {/* Market Brackets */}
-          <WidgetGridV2.Area area="brackets" isExpanded={expandedWidgets.brackets} expansionSize="medium">
+          <div key="brackets" area="brackets" className="h-full">
             <MarketBrackets
               citySlug={citySlug}
               cityName={city.name}
@@ -312,10 +309,10 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.brackets}
               onToggleExpand={() => toggleExpansion('brackets')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
           {/* Weather Map / Satellite */}
-          <WidgetGridV2.Area area="map" isExpanded={expandedWidgets.map} expansionSize="large">
+          <div key="map" area="map" className="h-full">
             <WeatherMap
               lat={city.lat}
               lon={city.lon}
@@ -323,10 +320,10 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.map}
               onToggleExpand={() => toggleExpansion('map')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
           {/* NWS Forecast Discussion */}
-          <WidgetGridV2.Area area="discussion" isExpanded={expandedWidgets.discussion} expansionSize="large">
+          <div key="discussion" area="discussion" className="h-full">
             <NWSDiscussionWidget
               lat={city.lat}
               lon={city.lon}
@@ -338,20 +335,32 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.discussion}
               onToggleExpand={() => toggleExpansion('discussion')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
-          {/* Nearby Stations (2x1 collapsed, 4x2 expanded) */}
-          <WidgetGridV2.Area area="nearby" isExpanded={expandedWidgets.nearby}>
+          {/* Nearby Stations */}
+          <div key="nearby" area="nearby" className="h-full">
             <NearbyStations
               citySlug={citySlug}
               isExpanded={expandedWidgets.nearby}
               onToggleExpand={() => toggleExpansion('nearby')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
+          {/* Alerts Widget - conditionally shown */}
+          {alerts && alerts.length > 0 && (
+            <div key="alerts" area="alerts" className="h-full">
+              <AlertsWidget
+                lat={city.lat}
+                lon={city.lon}
+                cityName={city.name}
+                isExpanded={expandedWidgets.alerts}
+                onToggleExpand={() => toggleExpansion('alerts')}
+              />
+            </div>
+          )}
 
-          {/* Wind + Resolution stacked */}
-          <WidgetGridV2.Area area="smallstack">
+          {/* Wind Widget */}
+          <div key="wind" area="wind" className="h-full">
             <WindWidget
               speed={weatherDetails.windSpeed}
               direction={weatherDetails.windDirection}
@@ -363,6 +372,10 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.wind}
               onToggleExpand={() => toggleExpansion('wind')}
             />
+          </div>
+
+          {/* Resolution Widget */}
+          <div key="resolution" area="resolution" className="h-full">
             <ResolutionWidget
               stationId={city.stationId}
               citySlug={citySlug}
@@ -372,28 +385,28 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.resolution}
               onToggleExpand={() => toggleExpansion('resolution')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
           {/* Rain/Snow Trading */}
-          <WidgetGridV2.Area area="pressure">
+          <div key="pressure" area="pressure" className="h-full">
             <RainSnowBracketsWidget
               citySlug={citySlug}
               cityName={city.name}
             />
-          </WidgetGridV2.Area>
+          </div>
 
           {/* Rain Accumulation */}
-          <WidgetGridV2.Area area="visibility" isExpanded={expandedWidgets.rain}>
+          <div key="visibility" area="visibility" className="h-full">
             <RainWidget
               citySlug={citySlug}
               cityName={city.name}
               isExpanded={expandedWidgets.rain}
               onToggleExpand={() => toggleExpansion('rain')}
             />
-          </WidgetGridV2.Area>
+          </div>
 
           {/* Rounding Calculator */}
-          <WidgetGridV2.Area area="rounding" isExpanded={expandedWidgets.rounding}>
+          <div key="rounding" area="rounding" className="h-full">
             <RoundingWidget
               currentTemp={currentTempF}
               runningHigh={runningHigh}
@@ -402,8 +415,8 @@ function CityDashboardContent({ city, citySlug }) {
               isExpanded={expandedWidgets.rounding}
               onToggleExpand={() => toggleExpansion('rounding')}
             />
-          </WidgetGridV2.Area>
-        </WidgetGridV2>
+          </div>
+        </CityWidgetGrid>
       </div>
       </div>
     </>

--- a/src/components/dashboard/CityWidgetGrid.jsx
+++ b/src/components/dashboard/CityWidgetGrid.jsx
@@ -1,0 +1,225 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import GridLayout from 'react-grid-layout';
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+import { RotateCcw } from 'lucide-react';
+import {
+  getCityLayout,
+  saveCityLayout,
+  resetCityLayout,
+  WIDGET_CONSTRAINTS,
+  shouldWidgetBeExpanded,
+} from '../../stores/cityLayoutStore';
+
+/**
+ * Hook to measure container width
+ */
+function useContainerWidth(ref) {
+  const [width, setWidth] = useState(800);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const measureWidth = () => {
+      const newWidth = element.offsetWidth;
+      if (newWidth > 0) {
+        setWidth(newWidth);
+      }
+    };
+
+    // Initial measurement
+    measureWidth();
+
+    // Set up ResizeObserver
+    const resizeObserver = new ResizeObserver(() => {
+      measureWidth();
+    });
+    resizeObserver.observe(element);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return width;
+}
+
+/**
+ * CityWidgetGrid - Draggable and resizable widget grid using react-grid-layout
+ *
+ * Replaces WidgetGridV2 with full drag/drop and resize support.
+ * Persists layout to localStorage per city.
+ */
+export default function CityWidgetGrid({
+  citySlug,
+  children,
+  expandedWidgets = {},
+  onExpansionChange,
+  absentWidgets = [],
+  className = '',
+}) {
+  const containerRef = useRef(null);
+  const width = useContainerWidth(containerRef);
+
+  // Load layout from storage
+  const [layout, setLayout] = useState(() => getCityLayout(citySlug));
+  const saveTimeoutRef = useRef(null);
+
+  // Determine columns based on width
+  // More aggressive breakpoints to use 4 columns earlier
+  const cols = useMemo(() => {
+    if (width < 400) return 1;
+    if (width < 550) return 2;
+    if (width < 700) return 3;
+    return 4;
+  }, [width]);
+
+  // Filter out absent widgets from layout and adjust for current column count
+  const filteredLayout = useMemo(() => {
+    return layout
+      .filter(item => !absentWidgets.includes(item.i))
+      .map(item => ({
+        ...item,
+        // Clamp x and w to fit current column count
+        x: Math.min(item.x, cols - 1),
+        w: Math.min(item.w, cols),
+      }));
+  }, [layout, absentWidgets, cols]);
+
+  // Debounced save to localStorage
+  const debouncedSave = useCallback((newLayout) => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      saveCityLayout(citySlug, newLayout);
+    }, 500);
+  }, [citySlug]);
+
+  // Handle layout change
+  const handleLayoutChange = useCallback((newLayout) => {
+    // Merge new positions with existing constraints
+    const mergedLayout = newLayout.map(item => ({
+      ...item,
+      ...(WIDGET_CONSTRAINTS[item.i] || {}),
+    }));
+    setLayout(mergedLayout);
+    debouncedSave(mergedLayout);
+  }, [debouncedSave]);
+
+  // Handle resize stop - check if widget should auto-expand
+  const handleResizeStop = useCallback((currentLayout, oldItem, newItem) => {
+    if (onExpansionChange) {
+      const shouldBeExpanded = shouldWidgetBeExpanded(newItem.i, newItem.w, newItem.h);
+      const currentlyExpanded = expandedWidgets[newItem.i] || false;
+
+      if (shouldBeExpanded !== currentlyExpanded) {
+        onExpansionChange(newItem.i, shouldBeExpanded);
+      }
+    }
+  }, [onExpansionChange, expandedWidgets]);
+
+  // Reset layout to default
+  const handleResetLayout = useCallback(() => {
+    resetCityLayout(citySlug);
+    setLayout(getCityLayout(citySlug));
+  }, [citySlug]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Map children to grid items
+  const gridItems = useMemo(() => {
+    const childArray = Array.isArray(children) ? children : [children];
+    return childArray
+      .filter(Boolean)
+      .map(child => {
+        // Get the widget ID from the child's area prop or key
+        const widgetId = child.props?.area || child.key;
+        if (!widgetId || absentWidgets.includes(widgetId)) {
+          return null;
+        }
+        return (
+          <div key={widgetId} className="city-widget-grid-item relative">
+            {/* Invisible drag handle overlay at top of widget */}
+            <div className="widget-drag-handle" />
+            {child}
+          </div>
+        );
+      })
+      .filter(Boolean);
+  }, [children, absentWidgets]);
+
+  return (
+    <div ref={containerRef} className={`city-widget-grid relative ${className}`}>
+      {/* Reset button */}
+      <button
+        onClick={handleResetLayout}
+        className="absolute -top-10 right-0 z-10 flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-white/60 hover:text-white/90 bg-black/20 hover:bg-black/40 rounded-lg transition-all"
+        title="Reset layout to default"
+      >
+        <RotateCcw className="w-3.5 h-3.5" />
+        <span>Reset Layout</span>
+      </button>
+
+      <GridLayout
+        className="layout"
+        layout={filteredLayout}
+        cols={cols}
+        rowHeight={140}
+        width={width}
+        margin={[12, 12]}
+        containerPadding={[0, 0]}
+        isDraggable={cols > 1}
+        isResizable={cols > 1}
+        draggableHandle=".widget-drag-handle"
+        useCSSTransforms={true}
+        compactType="vertical"
+        preventCollision={false}
+        onLayoutChange={handleLayoutChange}
+        onResizeStop={handleResizeStop}
+      >
+        {gridItems}
+      </GridLayout>
+    </div>
+  );
+}
+
+CityWidgetGrid.propTypes = {
+  citySlug: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  expandedWidgets: PropTypes.object,
+  onExpansionChange: PropTypes.func,
+  absentWidgets: PropTypes.array,
+  className: PropTypes.string,
+};
+
+/**
+ * Widget wrapper component - provides drag handle and consistent styling
+ */
+export function CityWidget({ id, children, className = '' }) {
+  return (
+    <div className={`city-widget h-full flex flex-col ${className}`}>
+      {/* Drag handle - full header area */}
+      <div className="widget-drag-handle cursor-grab active:cursor-grabbing" />
+      {/* Widget content */}
+      <div className="flex-1 min-h-0">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+CityWidget.propTypes = {
+  id: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  className: PropTypes.string,
+};

--- a/src/config/WidgetRegistry.js
+++ b/src/config/WidgetRegistry.js
@@ -10,6 +10,11 @@ import RainWidget from '../components/widgets/RainWidget';
 /**
  * Widget Registry
  * Central registry of all available widgets with metadata
+ *
+ * Grid constraints (for 4-column city dashboard grid):
+ * - minW/minH: Minimum size in grid units
+ * - maxW/maxH: Maximum size in grid units
+ * - defaultW/defaultH: Default size for workspace dashboard (12-column)
  */
 export const WIDGET_REGISTRY = {
   'live-market-brackets': {
@@ -20,11 +25,13 @@ export const WIDGET_REGISTRY = {
     component: LiveMarketBrackets,
     category: 'market',
     requiredProps: ['citySlug', 'cityName'],
-    // Grid layout properties (12-column grid, rowHeight: 80px)
+    // Grid layout properties (12-column grid for workspace, rowHeight: 80px)
     defaultW: 4,   // 1/3 width - fits 3 per row
     defaultH: 5,
-    minW: 3,
-    minH: 4,
+    minW: 1,
+    minH: 2,
+    maxW: 2,
+    maxH: 3,
   },
   'live-station-data': {
     id: 'live-station-data',
@@ -36,8 +43,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['stationId', 'cityName', 'timezone'],
     defaultW: 6,  // Half width (6/12 columns)
     defaultH: 5,
-    minW: 4,
-    minH: 4,
+    minW: 2,
+    minH: 1,
+    maxW: 4,
+    maxH: 2,
   },
   'nearby-stations-map': {
     id: 'nearby-stations-map',
@@ -49,8 +58,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['citySlug', 'cityName'],
     defaultW: 4,
     defaultH: 5,
-    minW: 3,
-    minH: 4,
+    minW: 2,
+    minH: 1,
+    maxW: 4,
+    maxH: 2,
   },
   'forecast-models': {
     id: 'forecast-models',
@@ -62,8 +73,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['citySlug'],
     defaultW: 4,
     defaultH: 5,
-    minW: 3,
-    minH: 4,
+    minW: 1,
+    minH: 1,
+    maxW: 4,
+    maxH: 2,
   },
   'forecast-discussion': {
     id: 'forecast-discussion',
@@ -75,8 +88,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['cityId'],
     defaultW: 4,
     defaultH: 4,
-    minW: 3,
-    minH: 3,
+    minW: 1,
+    minH: 1,
+    maxW: 4,
+    maxH: 4,
   },
   'nws-hourly-forecast': {
     id: 'nws-hourly-forecast',
@@ -88,8 +103,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['citySlug'],
     defaultW: 4,
     defaultH: 5,
-    minW: 3,
-    minH: 4,
+    minW: 2,
+    minH: 1,
+    maxW: 4,
+    maxH: 2,
   },
   'daily-summary': {
     id: 'daily-summary',
@@ -101,8 +118,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['citySlug', 'cityName'],
     defaultW: 4,
     defaultH: 4,
-    minW: 3,
-    minH: 3,
+    minW: 1,
+    minH: 1,
+    maxW: 2,
+    maxH: 2,
   },
   'rain-accumulation': {
     id: 'rain-accumulation',
@@ -114,8 +133,10 @@ export const WIDGET_REGISTRY = {
     requiredProps: ['citySlug', 'cityName'],
     defaultW: 4,
     defaultH: 5,
-    minW: 3,
-    minH: 4,
+    minW: 1,
+    minH: 1,
+    maxW: 2,
+    maxH: 2,
   },
 };
 

--- a/src/hooks/useWidgetSize.js
+++ b/src/hooks/useWidgetSize.js
@@ -1,0 +1,158 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+/**
+ * Size thresholds for widget content adaptation (in pixels)
+ * These determine when widgets should switch between compact/expanded content
+ */
+const SIZE_THRESHOLDS = {
+  // Width thresholds
+  compact: 200,    // Below this = ultra compact
+  medium: 320,     // Below this = compact, above = medium
+  large: 480,      // Above this = full/expanded
+
+  // Height thresholds
+  shortHeight: 150,
+  mediumHeight: 250,
+  tallHeight: 400,
+};
+
+/**
+ * Widget-specific thresholds for expansion suggestion
+ * When both width AND height exceed these, suggest expansion
+ */
+const WIDGET_EXPANSION_THRESHOLDS = {
+  models: { width: 400, height: 280 },
+  brackets: { width: 280, height: 350 },
+  map: { width: 400, height: 300 },
+  discussion: { width: 450, height: 400 },
+  nearby: { width: 450, height: 250 },
+  wind: { width: 280, height: 200 },
+  resolution: { width: 280, height: 200 },
+  rounding: { width: 280, height: 200 },
+  alerts: { width: 280, height: 200 },
+  rain: { width: 280, height: 200 },
+  pressure: { width: 280, height: 200 },
+  visibility: { width: 280, height: 200 },
+};
+
+/**
+ * Hook to track widget dimensions using ResizeObserver
+ *
+ * @param {Object} options - Configuration options
+ * @param {string} options.widgetType - Type of widget for threshold lookup
+ * @param {Function} options.onExpansionSuggestion - Callback when expansion state should change
+ * @returns {Object} - { ref, width, height, sizeClass, shouldBeExpanded }
+ */
+export function useWidgetSize(options = {}) {
+  const { widgetType, onExpansionSuggestion } = options;
+  const ref = useRef(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const lastSuggestionRef = useRef(null);
+
+  // Calculate size class based on width
+  const sizeClass = (() => {
+    if (dimensions.width < SIZE_THRESHOLDS.compact) return 'compact';
+    if (dimensions.width < SIZE_THRESHOLDS.medium) return 'medium';
+    if (dimensions.width < SIZE_THRESHOLDS.large) return 'large';
+    return 'expanded';
+  })();
+
+  // Calculate height class
+  const heightClass = (() => {
+    if (dimensions.height < SIZE_THRESHOLDS.shortHeight) return 'short';
+    if (dimensions.height < SIZE_THRESHOLDS.mediumHeight) return 'medium';
+    if (dimensions.height < SIZE_THRESHOLDS.tallHeight) return 'tall';
+    return 'expanded';
+  })();
+
+  // Determine if widget should be expanded based on its size
+  const shouldBeExpanded = (() => {
+    if (!widgetType) return false;
+    const thresholds = WIDGET_EXPANSION_THRESHOLDS[widgetType];
+    if (!thresholds) return false;
+
+    return dimensions.width >= thresholds.width && dimensions.height >= thresholds.height;
+  })();
+
+  // Notify expansion change
+  const handleExpansionSuggestion = useCallback((newSuggestion) => {
+    if (onExpansionSuggestion && lastSuggestionRef.current !== newSuggestion) {
+      lastSuggestionRef.current = newSuggestion;
+      onExpansionSuggestion(newSuggestion);
+    }
+  }, [onExpansionSuggestion]);
+
+  // Set up ResizeObserver
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setDimensions({ width, height });
+      }
+    });
+
+    resizeObserver.observe(element);
+
+    // Initial measurement
+    const { width, height } = element.getBoundingClientRect();
+    setDimensions({ width, height });
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  // Trigger expansion suggestion callback when shouldBeExpanded changes
+  useEffect(() => {
+    if (widgetType && onExpansionSuggestion) {
+      handleExpansionSuggestion(shouldBeExpanded);
+    }
+  }, [shouldBeExpanded, widgetType, onExpansionSuggestion, handleExpansionSuggestion]);
+
+  return {
+    ref,
+    width: dimensions.width,
+    height: dimensions.height,
+    sizeClass,
+    heightClass,
+    shouldBeExpanded,
+    isCompact: sizeClass === 'compact',
+    isMedium: sizeClass === 'medium',
+    isLarge: sizeClass === 'large' || sizeClass === 'expanded',
+    isShort: heightClass === 'short',
+    isTall: heightClass === 'tall' || heightClass === 'expanded',
+  };
+}
+
+/**
+ * Simple hook to just get element dimensions without expansion logic
+ */
+export function useElementSize() {
+  const ref = useRef(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setSize({ width, height });
+      }
+    });
+
+    resizeObserver.observe(element);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return { ref, ...size };
+}
+
+export default useWidgetSize;

--- a/src/stores/cityLayoutStore.js
+++ b/src/stores/cityLayoutStore.js
@@ -1,0 +1,161 @@
+/**
+ * City Layout Store
+ * Persists widget layouts per city to localStorage
+ */
+
+const STORAGE_KEY_PREFIX = 'toasty_city_layout_v1_';
+
+/**
+ * Default layout for city dashboards
+ * Uses a 4-column grid system
+ * Each item: { i: widgetId, x: col, y: row, w: width, h: height }
+ */
+const DEFAULT_LAYOUT = [
+  // Row 1: Models (2x2) + Brackets (1x2 tall) + Map (2x2)
+  { i: 'models', x: 0, y: 0, w: 2, h: 2, minW: 1, minH: 1, maxW: 4, maxH: 2 },
+  { i: 'brackets', x: 2, y: 0, w: 1, h: 2, minW: 1, minH: 2, maxW: 2, maxH: 3 },
+  { i: 'map', x: 3, y: 0, w: 1, h: 2, minW: 1, minH: 1, maxW: 4, maxH: 3 },
+
+  // Row 3: Discussion (2x2) + Nearby (2x1)
+  { i: 'discussion', x: 0, y: 2, w: 2, h: 2, minW: 1, minH: 1, maxW: 4, maxH: 4 },
+  { i: 'nearby', x: 2, y: 2, w: 2, h: 1, minW: 2, minH: 1, maxW: 4, maxH: 2 },
+
+  // Row 4: Wind (1x1) + Resolution (1x1) + Pressure/RainSnow (1x1) + Visibility/Rain (1x1)
+  { i: 'wind', x: 2, y: 3, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  { i: 'resolution', x: 3, y: 3, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+
+  // Row 5: Small widgets
+  { i: 'pressure', x: 0, y: 4, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  { i: 'visibility', x: 1, y: 4, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  { i: 'rounding', x: 2, y: 4, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+
+  // Alerts - only shown when there are alerts
+  { i: 'alerts', x: 3, y: 4, w: 1, h: 1, minW: 1, minH: 1, maxW: 2, maxH: 2 },
+];
+
+/**
+ * Widget size constraints (in grid units)
+ * Used to enforce min/max during resize
+ */
+export const WIDGET_CONSTRAINTS = {
+  models: { minW: 1, minH: 1, maxW: 4, maxH: 2 },
+  brackets: { minW: 1, minH: 2, maxW: 2, maxH: 3 },
+  map: { minW: 1, minH: 1, maxW: 4, maxH: 3 },
+  discussion: { minW: 1, minH: 1, maxW: 4, maxH: 4 },
+  nearby: { minW: 2, minH: 1, maxW: 4, maxH: 2 },
+  alerts: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  wind: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  resolution: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  pressure: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  visibility: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+  rounding: { minW: 1, minH: 1, maxW: 2, maxH: 2 },
+};
+
+/**
+ * Thresholds for auto-expanding widgets based on size
+ * When a widget is resized past these thresholds, it auto-expands
+ */
+export const EXPANSION_THRESHOLDS = {
+  models: { expandW: 3, expandH: 2 },
+  brackets: { expandW: 2, expandH: 3 },
+  map: { expandW: 2, expandH: 2 },
+  discussion: { expandW: 3, expandH: 3 },
+  nearby: { expandW: 3, expandH: 2 },
+  alerts: { expandW: 2, expandH: 2 },
+  wind: { expandW: 2, expandH: 2 },
+  resolution: { expandW: 2, expandH: 2 },
+  rounding: { expandW: 2, expandH: 2 },
+};
+
+/**
+ * Get storage key for a city
+ */
+function getStorageKey(citySlug) {
+  return `${STORAGE_KEY_PREFIX}${citySlug}`;
+}
+
+/**
+ * Get saved layout for a city, or generate default
+ * @param {string} citySlug - The city identifier
+ * @returns {Array} Layout array for react-grid-layout
+ */
+export function getCityLayout(citySlug) {
+  try {
+    const key = getStorageKey(citySlug);
+    const stored = localStorage.getItem(key);
+
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Validate layout has required properties
+      if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].i) {
+        // Merge with constraints to ensure they're up-to-date
+        return parsed.map(item => ({
+          ...item,
+          ...(WIDGET_CONSTRAINTS[item.i] || {}),
+        }));
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to load city layout:', e);
+  }
+
+  // Return default layout with constraints
+  return DEFAULT_LAYOUT.map(item => ({
+    ...item,
+    ...(WIDGET_CONSTRAINTS[item.i] || {}),
+  }));
+}
+
+/**
+ * Save layout for a city
+ * @param {string} citySlug - The city identifier
+ * @param {Array} layout - Layout array from react-grid-layout
+ */
+export function saveCityLayout(citySlug, layout) {
+  try {
+    const key = getStorageKey(citySlug);
+    // Store only position/size, not constraints (those come from WIDGET_CONSTRAINTS)
+    const toStore = layout.map(({ i, x, y, w, h }) => ({ i, x, y, w, h }));
+    localStorage.setItem(key, JSON.stringify(toStore));
+  } catch (e) {
+    console.warn('Failed to save city layout:', e);
+  }
+}
+
+/**
+ * Reset layout for a city to default
+ * @param {string} citySlug - The city identifier
+ */
+export function resetCityLayout(citySlug) {
+  try {
+    const key = getStorageKey(citySlug);
+    localStorage.removeItem(key);
+  } catch (e) {
+    console.warn('Failed to reset city layout:', e);
+  }
+}
+
+/**
+ * Get default layout (without loading from storage)
+ * @returns {Array} Default layout array
+ */
+export function getDefaultLayout() {
+  return DEFAULT_LAYOUT.map(item => ({
+    ...item,
+    ...(WIDGET_CONSTRAINTS[item.i] || {}),
+  }));
+}
+
+/**
+ * Check if a widget should be expanded based on its current size
+ * @param {string} widgetId - Widget identifier
+ * @param {number} w - Current width in grid units
+ * @param {number} h - Current height in grid units
+ * @returns {boolean} Whether the widget should be in expanded state
+ */
+export function shouldWidgetBeExpanded(widgetId, w, h) {
+  const thresholds = EXPANSION_THRESHOLDS[widgetId];
+  if (!thresholds) return false;
+
+  return w >= thresholds.expandW || h >= thresholds.expandH;
+}

--- a/src/styles/liquid-glass.css
+++ b/src/styles/liquid-glass.css
@@ -962,3 +962,155 @@ body {
 .widget-grid-v2 .widget-area-transition {
   transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
+
+/* ===== CITY WIDGET GRID - React Grid Layout ===== */
+/* Draggable and resizable widget grid for city dashboards */
+
+.city-widget-grid {
+  width: 100%;
+  position: relative;
+}
+
+/* Grid item styling */
+.city-widget-grid-item {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.city-widget-grid-item > * {
+  height: 100%;
+  width: 100%;
+}
+
+/* Drag handle - invisible overlay at top of widget */
+.widget-drag-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  z-index: 10;
+  cursor: grab;
+  background: transparent;
+}
+
+.widget-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* React Grid Layout overrides */
+.city-widget-grid .react-grid-layout {
+  position: relative;
+}
+
+/* Placeholder during drag */
+.city-widget-grid .react-grid-placeholder {
+  background: rgba(0, 122, 255, 0.15) !important;
+  border: 2px dashed rgba(0, 122, 255, 0.4) !important;
+  border-radius: var(--radius-lg) !important;
+  transition: all 0.15s ease !important;
+}
+
+/* Item being dragged */
+.city-widget-grid .react-grid-item.react-draggable-dragging {
+  z-index: 100;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.3),
+    0 0 0 2px rgba(0, 122, 255, 0.5);
+  opacity: 0.9;
+  transform: scale(1.02);
+}
+
+/* Item being resized */
+.city-widget-grid .react-grid-item.resizing {
+  z-index: 100;
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.25),
+    0 0 0 2px rgba(0, 122, 255, 0.4);
+}
+
+/* Resize handle styling - corner dot */
+.city-widget-grid .react-resizable-handle {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  bottom: 4px;
+  right: 4px;
+  cursor: se-resize;
+  z-index: 20;
+}
+
+.city-widget-grid .react-resizable-handle::before {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  transition: all 0.15s ease;
+}
+
+.city-widget-grid .react-resizable-handle:hover::before {
+  background: rgba(0, 122, 255, 0.6);
+  transform: scale(1.2);
+  box-shadow: 0 0 8px rgba(0, 122, 255, 0.4);
+}
+
+.city-widget-grid .react-resizable-handle:active::before {
+  background: rgba(0, 122, 255, 0.8);
+  transform: scale(1.4);
+}
+
+/* Alternative: L-shaped resize handle */
+.city-widget-grid .react-resizable-handle-se {
+  bottom: 0;
+  right: 0;
+  cursor: se-resize;
+}
+
+/* Smooth transitions for grid items */
+.city-widget-grid .react-grid-item {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.city-widget-grid .react-grid-item:not(.react-draggable-dragging):not(.resizing) {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Hover effect on grid items */
+.city-widget-grid .react-grid-item:hover:not(.react-draggable-dragging):not(.resizing) {
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+/* Widget content inside grid items */
+.city-widget-grid .glass-widget {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Mobile: disable drag/resize for better touch experience */
+@media (max-width: 640px) {
+  .widget-drag-handle {
+    display: none;
+  }
+
+  .city-widget-grid .react-resizable-handle {
+    display: none;
+  }
+
+  .city-widget-grid .react-grid-item {
+    cursor: default;
+  }
+}
+
+/* Reduce motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .city-widget-grid .react-grid-item,
+  .city-widget-grid .react-grid-placeholder {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Migrate city dashboard from custom CSS Grid engine to React Grid Layout
- Enable drag-and-drop widget reordering via header drag handles
- Add resize handles with min/max constraints per widget type
- Persist layout to localStorage per city with reset functionality

## Changes

### New Files
- `src/stores/cityLayoutStore.js` - Layout persistence with default layouts and constraints
- `src/components/dashboard/CityWidgetGrid.jsx` - React Grid Layout wrapper with 4-column responsive grid
- `src/hooks/useWidgetSize.js` - ResizeObserver hook for widget size tracking

### Modified Files
- `CityDashboardNew.jsx` - Replace WidgetGridV2 with CityWidgetGrid
- `WidgetRegistry.js` - Add maxW/maxH constraints for all widgets
- `liquid-glass.css` - Glass-themed styles for drag/resize handles and placeholders

## Features
- 4-column responsive grid (adjusts to 1-3 columns on smaller screens)
- Invisible drag handle overlay on top 48px of each widget
- Corner dot resize handle with blue highlight on hover
- Blue dashed placeholder during drag operations
- "Reset Layout" button to restore default positions
- Mobile disables drag/resize for better touch experience
- Respects prefers-reduced-motion

## Test plan
- [ ] Open city dashboard, verify widgets render in grid layout
- [ ] Drag widgets to new positions, verify they snap to grid
- [ ] Resize widgets using corner handles, verify min/max constraints
- [ ] Refresh page, verify layout is preserved
- [ ] Click Reset Layout, verify default layout restored
- [ ] Test on mobile viewport, verify drag/resize disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)